### PR TITLE
Update design system colors to the orange learning palette

### DIFF
--- a/SamuiLanguageSchool/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SamuiLanguageSchool/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x5F",
+          "red" : "0xFF"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/SamuiLanguageSchool/DesignSystem/SLSColors.swift
+++ b/SamuiLanguageSchool/DesignSystem/SLSColors.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 enum SLSColors {
-    static let brand = Color(hex: 0x2F80FF)
-    static let brandStrong = Color(hex: 0x1764F5)
-    static let brandSoft = Color(hex: 0xDBEAFE)
-    static let brandMuted = Color(hex: 0x9BB9F4)
+    static let brand = Color(hex: 0xFF5F00)
+    static let brandStrong = Color(hex: 0xF24A00)
+    static let brandSoft = Color(hex: 0xFFECD2)
+    static let brandMuted = Color(hex: 0xFFB47D)
 
-    static let purple = Color(hex: 0x9A20FF)
-    static let purpleSoft = Color(hex: 0xF0D9FF)
-    static let purpleSurface = Color(hex: 0xFBF5FF)
+    static let orange = Color(hex: 0xFF7A1A)
+    static let orangeSoft = Color(hex: 0xFFF4E6)
+    static let warmSurface = Color(hex: 0xFFF8EF)
+    static let lavenderSoft = Color(hex: 0xF2E2FF)
 
     static let background = Color(hex: 0xF7F8FA)
     static let surface = Color.white
@@ -25,7 +26,7 @@ enum SLSColors {
     static let border = Color(hex: 0xE3E5EA)
     static let separator = Color(hex: 0xE5E7EB)
     static let disabledFill = Color(hex: 0xE4E6EB)
-    static let blueSurface = Color(hex: 0xEEF6FF)
+    static let lessonSurface = Color(hex: 0xFFF7EC)
 }
 
 extension Color {

--- a/SamuiLanguageSchool/DesignSystem/SLSComponents.swift
+++ b/SamuiLanguageSchool/DesignSystem/SLSComponents.swift
@@ -61,8 +61,8 @@ struct SLSCard<Content: View>: View {
 
 struct SLSPill: View {
     let title: String
-    var foreground: Color = SLSColors.purple
-    var background: Color = SLSColors.purpleSoft
+    var foreground: Color = SLSColors.brand
+    var background: Color = SLSColors.brandSoft
 
     var body: some View {
         Text(title)

--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -124,7 +124,7 @@ struct StartView: View {
                         .font(.system(size: 24))
                         .foregroundStyle(SLSColors.textPrimary)
                         .frame(width: 48, height: 48)
-                        .background(SLSColors.purpleSoft)
+                        .background(SLSColors.lavenderSoft)
                         .clipShape(Circle())
 
                     VStack(alignment: .leading, spacing: 4) {

--- a/SamuiLanguageSchool/Features/Theory/TheoryView.swift
+++ b/SamuiLanguageSchool/Features/Theory/TheoryView.swift
@@ -48,7 +48,7 @@ struct TheoryView: View {
                     formula: "Verb + -ed",
                     highlightedPart: "-ed",
                     example: "Example: work -> worked, play -> played",
-                    background: SLSColors.blueSurface
+                    background: SLSColors.lessonSurface
                 )
 
                 LessonInfoPanel(
@@ -56,7 +56,7 @@ struct TheoryView: View {
                     formula: "Special forms",
                     highlightedPart: nil,
                     example: "Example: go -> went, see -> saw",
-                    background: SLSColors.purpleSurface
+                    background: SLSColors.lessonSurface
                 )
             }
         }
@@ -100,7 +100,7 @@ private struct LessonHeroCard: View {
         .frame(maxWidth: .infinity, minHeight: 190, alignment: .leading)
         .background(
             LinearGradient(
-                colors: [SLSColors.brand.opacity(0.94), SLSColors.purple],
+                colors: [SLSColors.orange, SLSColors.brandStrong],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )


### PR DESCRIPTION
## Summary
- Replace the old blue and purple brand tokens with the warm orange palette shown in the updated mockups
- Update shared design system components so pills, lesson panels, and hero surfaces pick up the new tokens consistently
- Set the asset catalog accent color to match the new brand color

## Testing
- Built the app locally with `xcodebuild` for the iPhone 17 simulator target
- Verified the project compiles after the token and component updates