### PR TITLE
Add lesson summary screen backed by JSON lesson content

### DIFF
--- a/SamuiLanguageSchool/ContentView.swift
+++ b/SamuiLanguageSchool/ContentView.swift
@@ -13,10 +13,15 @@ struct ContentView: View {
     var body: some View {
         NavigationStack(path: $path) {
             StartView {
-                path.append(.theory)
+                path.append(.lesson)
             }
             .navigationDestination(for: Route.self) { route in
                 switch route {
+                case .lesson:
+                    LessonView(
+                        onBack: pop,
+                        onStartPractice: { path.append(.practice) }
+                    )
                 case .theory:
                     TheoryView(
                         onBack: pop,
@@ -36,6 +41,7 @@ struct ContentView: View {
 }
 
 private enum Route: Hashable {
+    case lesson
     case theory
     case practice
 }

--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -1,0 +1,340 @@
+//
+//  LessonView.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import SwiftUI
+
+struct LessonView: View {
+    @StateObject private var viewModel: LessonViewModel
+
+    var onBack: () -> Void
+    var onStartPractice: () -> Void
+
+    init(
+        viewModel: @autoclosure @escaping () -> LessonViewModel = LessonViewModel(),
+        onBack: @escaping () -> Void,
+        onStartPractice: @escaping () -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+        self.onBack = onBack
+        self.onStartPractice = onStartPractice
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            SLSColors.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                SLSTopBar(title: "Lesson", backAction: onBack)
+
+                content
+            }
+
+            SLSBottomActionBar(
+                title: viewModel.primaryPracticeLabel,
+                isEnabled: viewModel.lesson != nil,
+                action: onStartPractice
+            )
+        }
+        .navigationBarBackButtonHidden()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let lesson = viewModel.lesson {
+            lessonContent(lesson)
+        } else {
+            errorContent
+        }
+    }
+
+    private func lessonContent(_ lesson: LessonContentModel) -> some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 22) {
+                LessonSummaryHero(summary: lesson.screenSummary)
+                LearningPathSection(steps: lesson.learningPath)
+                ObjectivesSection(objectives: lesson.objectives)
+                DifficultyGuideSection(
+                    entries: lesson.difficultyGuide,
+                    practiceTasks: lesson.practiceTasks
+                )
+            }
+            .padding(.horizontal, SLSSpacing.lg)
+            .padding(.top, 24)
+            .padding(.bottom, 124)
+        }
+    }
+
+    private var errorContent: some View {
+        VStack(spacing: SLSSpacing.lg) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+
+            Text("Lesson unavailable")
+                .font(SLSTypography.sectionTitle)
+                .foregroundStyle(SLSColors.textPrimary)
+
+            Text(viewModel.errorMessage ?? "Could not load lesson content.")
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Button("Retry") {
+                viewModel.load()
+            }
+            .font(SLSTypography.bodyStrong)
+            .foregroundStyle(SLSColors.brand)
+        }
+        .padding(SLSSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct LessonSummaryHero: View {
+    let summary: LessonContentModel.ScreenSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 28) {
+            HStack(alignment: .top) {
+                SLSPill(
+                    title: summary.lessonBadge,
+                    foreground: .white,
+                    background: .white.opacity(0.22)
+                )
+                Spacer(minLength: SLSSpacing.sm)
+                Text(summary.levelLabel)
+                    .font(SLSTypography.caption)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 13)
+                    .padding(.vertical, 7)
+                    .background(.white.opacity(0.18))
+                    .clipShape(Capsule())
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                Text(summary.themeTitle)
+                    .font(.system(size: 32, weight: .bold))
+                    .foregroundStyle(.white)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(summary.shortDescription)
+                    .font(SLSTypography.heroSubtitle)
+                    .foregroundStyle(.white.opacity(0.92))
+                    .lineSpacing(5)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: SLSSpacing.md) {
+                SummaryMetric(iconName: "clock", label: summary.estimatedReadTimeLabel)
+                if let progressLabel = summary.progressLabel {
+                    SummaryMetric(iconName: "checklist", label: progressLabel)
+                }
+            }
+        }
+        .padding(26)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(
+                colors: [SLSColors.orange, SLSColors.brandStrong],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.xl, style: .continuous))
+    }
+}
+
+private struct SummaryMetric: View {
+    let iconName: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: iconName)
+                .font(.system(size: 14, weight: .semibold))
+            Text(label)
+                .font(.system(size: 14, weight: .semibold))
+                .lineLimit(2)
+                .minimumScaleFactor(0.86)
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.18))
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
+    }
+}
+
+private struct LearningPathSection: View {
+    let steps: [LessonContentModel.LearningPathStep]
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 22) {
+                SectionHeader(title: "Learning Path", iconName: "map.fill")
+
+                VStack(spacing: 18) {
+                    ForEach(Array(steps.enumerated()), id: \.element.id) { index, step in
+                        LearningPathRow(stepNumber: index + 1, step: step)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct LearningPathRow: View {
+    let stepNumber: Int
+    let step: LessonContentModel.LearningPathStep
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SLSSpacing.md) {
+            Text("\(stepNumber)")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(SLSColors.brand)
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(step.title)
+                    .font(SLSTypography.bodyStrong)
+                    .foregroundStyle(SLSColors.textPrimary)
+
+                Text(step.instructions)
+                    .font(.system(size: 17, weight: .regular))
+                    .foregroundStyle(SLSColors.textSecondary)
+                    .lineSpacing(4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ObjectivesSection: View {
+    let objectives: [String]
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 18) {
+                SectionHeader(title: "Objectives", iconName: "target")
+
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(Array(objectives.enumerated()), id: \.offset) { _, objective in
+                        ObjectiveRow(text: objective)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ObjectiveRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SLSSpacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+                .padding(.top, 2)
+
+            Text(text)
+                .font(.system(size: 17, weight: .regular))
+                .foregroundStyle(SLSColors.textPrimary)
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct DifficultyGuideSection: View {
+    let entries: [LessonContentModel.DifficultyGuideEntry]
+    let practiceTasks: [LessonContentModel.PracticeTask]
+
+    private var taskTitlesByID: [String: String] {
+        Dictionary(uniqueKeysWithValues: practiceTasks.map { ($0.id, $0.title) })
+    }
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 18) {
+                SectionHeader(title: "Difficulty Guide", iconName: "chart.bar.fill")
+
+                VStack(spacing: 14) {
+                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                        DifficultyGuideRow(
+                            entry: entry,
+                            taskTitles: entry.taskIds.map { taskTitlesByID[$0] ?? $0 }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct DifficultyGuideRow: View {
+    let entry: LessonContentModel.DifficultyGuideEntry
+    let taskTitles: [String]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SLSSpacing.md) {
+            Text(entry.rating)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(SLSColors.brand)
+                .frame(width: 42, height: 42)
+                .background(SLSColors.brandSoft)
+                .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(entry.label)
+                    .font(SLSTypography.bodyStrong)
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(taskTitles.joined(separator: ", "))
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(SLSColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SLSColors.lessonSurface)
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+}
+
+private struct SectionHeader: View {
+    let title: String
+    let iconName: String
+
+    var body: some View {
+        HStack(spacing: SLSSpacing.sm) {
+            Image(systemName: iconName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+                .frame(width: 34, height: 34)
+                .background(SLSColors.brandSoft)
+                .clipShape(Circle())
+
+            Text(title)
+                .font(SLSTypography.sectionTitle)
+                .foregroundStyle(SLSColors.textPrimary)
+        }
+    }
+}
+
+#Preview {
+    LessonView(onBack: {}, onStartPractice: {})
+}

--- a/SamuiLanguageSchool/Features/Lesson/LessonViewModel.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  LessonViewModel.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class LessonViewModel: ObservableObject {
+    @Published private(set) var lesson: LessonContentModel?
+    @Published private(set) var errorMessage: String?
+
+    private let provider: any LessonContentProviding
+    private let lessonID: String?
+
+    init(
+        provider: any LessonContentProviding = LessonContentProvider(),
+        lessonID: String? = "articles-discourse-part-2"
+    ) {
+        self.provider = provider
+        self.lessonID = lessonID
+        load()
+    }
+
+    var screenTitle: String {
+        lesson?.screenSummary.themeTitle ?? "Lesson"
+    }
+
+    var primaryPracticeLabel: String {
+        lesson?.screenSummary.primaryPracticeLabel ?? "Start Practice"
+    }
+
+    func load() {
+        do {
+            lesson = try provider.lessonContent(id: lessonID)
+            errorMessage = nil
+        } catch {
+            lesson = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/SamuiLanguageSchool/Models/LessonContentModel.swift
+++ b/SamuiLanguageSchool/Models/LessonContentModel.swift
@@ -1,0 +1,225 @@
+//
+//  LessonContentModel.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import Foundation
+
+struct LessonContentModel: Decodable, Identifiable {
+    let id: String
+    let title: String
+    let level: Level
+    let subtitle: String
+    let estimatedMinutes: EstimatedMinutes
+    let tags: [String]
+    let source: Source
+    let screenSummary: ScreenSummary
+    let learningPath: [LearningPathStep]
+    let objectives: [String]
+    let difficultyGuide: [DifficultyGuideEntry]
+    let review: Review?
+    let theorySections: [TheorySection]
+    let practiceTasks: [PracticeTask]
+    let answerKey: [AnswerKeyTask]
+    let selfAssessment: [String]?
+}
+
+extension LessonContentModel {
+    struct EstimatedMinutes: Decodable {
+        let min: Int
+        let max: Int
+    }
+
+    struct Source: Decodable {
+        let fileName: String
+        let pageCount: Int
+        let extractionMethod: String?
+    }
+
+    struct Level: Decodable {
+        let code: String
+        let label: String
+        let descriptor: String?
+    }
+
+    struct ScreenSummary: Decodable {
+        let themeTitle: String
+        let levelLabel: String
+        let lessonBadge: String
+        let shortDescription: String
+        let estimatedReadTimeLabel: String
+        let primaryPracticeLabel: String?
+        let progressLabel: String?
+    }
+
+    struct LearningPathStep: Decodable, Identifiable {
+        let id: String
+        let title: String
+        let instructions: String
+    }
+
+    struct DifficultyGuideEntry: Decodable {
+        let rating: String
+        let label: String
+        let taskIds: [String]
+    }
+
+    struct ContentBlock: Decodable {
+        let type: ContentBlockType
+        let title: String?
+        let text: String?
+        let items: [String]?
+        let formula: String?
+        let columns: [String]?
+        let rows: [[String: JSONValue]]?
+        let examples: [String]?
+        let incorrect: String?
+        let correct: String?
+        let explanation: String?
+        let calloutType: String?
+        let caption: String?
+    }
+
+    enum ContentBlockType: String, Decodable {
+        case paragraph
+        case ruleList
+        case formula
+        case example
+        case exampleList
+        case table
+        case callout
+        case comparison
+        case modelText
+        case checklist
+    }
+
+    struct Review: Decodable {
+        let title: String
+        let contentBlocks: [ContentBlock]
+        let warmUpTask: PracticeTask?
+    }
+
+    struct TheorySection: Decodable, Identifiable {
+        let id: String
+        let title: String
+        let order: Int
+        let contentBlocks: [ContentBlock]
+        let tryItTaskIds: [String]
+    }
+
+    struct PracticeTask: Decodable, Identifiable {
+        let id: String
+        let title: String
+        let sourceLabel: String?
+        let kind: PracticeTaskKind
+        let mode: PracticeTaskMode
+        let difficulty: String?
+        let estimatedMinutes: EstimatedMinutes?
+        let instructions: String
+        let stimulus: String?
+        let supportingPrompts: [String]?
+        let items: [TaskItem]
+    }
+
+    enum PracticeTaskKind: String, Decodable {
+        case tryIt
+        case activity
+        case warmUp
+    }
+
+    enum PracticeTaskMode: String, Decodable {
+        case noticing
+        case practice
+        case production
+        case review
+    }
+
+    struct TaskItem: Decodable, Identifiable {
+        let id: String
+        let type: TaskItemType
+        let number: LessonContentNumber?
+        let prompt: String
+        let context: String?
+        let answerType: String?
+        let options: [String]?
+        let targetForm: String?
+        let targetForms: [String]?
+        let categories: [String]?
+        let text: String?
+        let original: String?
+        let newSubject: String?
+        let checklist: [String]?
+    }
+
+    enum TaskItemType: String, Decodable {
+        case gapFill
+        case multipleChoice
+        case rewrite
+        case sorting
+        case labeling
+        case errorCorrection
+        case tableCompletion
+        case paragraphWriting
+        case speakingPrompt
+        case freeResponse
+    }
+
+    struct AnswerEntry: Decodable {
+        let itemId: String
+        let answer: JSONValue?
+        let acceptedAnswers: [String]?
+        let sampleAnswers: [String]?
+        let explanation: String?
+        let errorType: String?
+        let notes: String?
+    }
+
+    struct AnswerKeyTask: Decodable {
+        let taskId: String
+        let entries: [AnswerEntry]
+        let teacherNotes: String?
+    }
+}
+
+enum LessonContentNumber: Decodable {
+    case integer(Int)
+    case string(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Int.self) {
+            self = .integer(value)
+            return
+        }
+        self = .string(try container.decode(String.self))
+    }
+}
+
+enum JSONValue: Decodable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: JSONValue].self))
+        }
+    }
+}

--- a/SamuiLanguageSchool/Services/LessonContentProvider.swift
+++ b/SamuiLanguageSchool/Services/LessonContentProvider.swift
@@ -1,0 +1,73 @@
+//
+//  LessonContentProvider.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import Foundation
+
+protocol LessonContentProviding {
+    func lessonContent(id: String?) throws -> LessonContentModel
+}
+
+struct LessonContentProvider: LessonContentProviding {
+    enum ProviderError: LocalizedError {
+        case missingResource(String)
+        case emptyLessonList
+        case lessonNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingResource(let fileName):
+                "Could not find \(fileName) in the app bundle."
+            case .emptyLessonList:
+                "The lesson content file does not contain any lessons."
+            case .lessonNotFound(let id):
+                "Could not find a lesson with id \(id)."
+            }
+        }
+    }
+
+    private let resourceName: String
+    private let resourceExtension: String
+    private let bundle: Bundle
+    private let decoder: JSONDecoder
+
+    init(
+        resourceName: String = "lessons",
+        resourceExtension: String = "json",
+        bundle: Bundle = .main,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.resourceName = resourceName
+        self.resourceExtension = resourceExtension
+        self.bundle = bundle
+        self.decoder = decoder
+    }
+
+    func lessonContent(id: String? = nil) throws -> LessonContentModel {
+        let lessons = try loadLessons()
+
+        if let id {
+            guard let lesson = lessons.first(where: { $0.id == id }) else {
+                throw ProviderError.lessonNotFound(id)
+            }
+            return lesson
+        }
+
+        guard let lesson = lessons.first else {
+            throw ProviderError.emptyLessonList
+        }
+        return lesson
+    }
+
+    private func loadLessons() throws -> [LessonContentModel] {
+        guard let url = bundle.url(forResource: resourceName, withExtension: resourceExtension) else {
+            throw ProviderError.missingResource("\(resourceName).\(resourceExtension)")
+        }
+
+        let data = try Data(contentsOf: url)
+        return try decoder.decode([LessonContentModel].self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
- Added a new lesson overview screen and view model, then routed the start flow to open it before practice.
- Introduced schema-backed lesson content models and a `LessonContentProvider` that decodes `lessons.json` into typed app data.
- Updated the difficulty guide to display learner-facing practice task titles instead of raw task IDs.

## Testing
- `xcodebuild -scheme SamuiLanguageSchool -destination 'platform=iOS Simulator,name=iPhone 17' build`

Resolves #3 