### PR TITLE
Format difficulty guide activity titles as numbered entries

### DIFF
--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -300,9 +300,10 @@ private struct DifficultyGuideRow: View {
                     .foregroundStyle(SLSColors.textPrimary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Text(taskTitles.joined(separator: ", "))
+                Text(DifficultyGuideTitleFormatter.listText(for: taskTitles))
                     .font(.system(size: 15, weight: .regular))
                     .foregroundStyle(SLSColors.textSecondary)
+                    .lineSpacing(4)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -312,6 +313,37 @@ private struct DifficultyGuideRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SLSColors.lessonSurface)
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+}
+
+enum DifficultyGuideTitleFormatter {
+    nonisolated static func listText(for titles: [String]) -> String {
+        titles
+            .map(formattedTitle)
+            .joined(separator: "\n")
+    }
+
+    nonisolated static func formattedTitle(_ title: String) -> String {
+        let prefix = "Activity "
+
+        guard title.hasPrefix(prefix) else {
+            return title
+        }
+
+        let titleWithoutPrefix = title.dropFirst(prefix.count)
+
+        guard let separatorRange = titleWithoutPrefix.range(of: " - ") else {
+            return title
+        }
+
+        let activityNumber = titleWithoutPrefix[..<separatorRange.lowerBound]
+
+        guard !activityNumber.isEmpty, activityNumber.allSatisfy(\.isNumber) else {
+            return title
+        }
+
+        let activityTitle = titleWithoutPrefix[separatorRange.upperBound...]
+        return "\(activityNumber) - \(activityTitle)"
     }
 }
 

--- a/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
+++ b/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
@@ -10,10 +10,28 @@ import Testing
 
 struct SamuiLanguageSchoolTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-        // Swift Testing Documentation
-        // https://developer.apple.com/documentation/testing
+    @Test func difficultyGuideTitleListUsesActivityNumbers() async throws {
+        let titles = [
+            "Activity 2 - Articles across a paragraph",
+            "Activity 3 - Abstract nouns: a, the, or zero article",
+            "Activity 4 - Generic the or zero article"
+        ]
+
+        #expect(
+            DifficultyGuideTitleFormatter.listText(for: titles) ==
+            """
+            2 - Articles across a paragraph
+            3 - Abstract nouns: a, the, or zero article
+            4 - Generic the or zero article
+            """
+        )
+    }
+
+    @Test func difficultyGuideTitleFormatterLeavesNonActivityTitlesUnchanged() async throws {
+        #expect(
+            DifficultyGuideTitleFormatter.formattedTitle("Try It A - Article tracking") ==
+            "Try It A - Article tracking"
+        )
     }
 
 }


### PR DESCRIPTION
## Summary
- Updated the lesson difficulty guide to render activity titles as numbered lines instead of repeating the `Activity` prefix.
- Added a small formatter to convert titles like `Activity 2 - ...` into `2 - ...` while leaving non-activity titles unchanged.
- Added unit coverage for the title formatting behavior.

## Testing
- Ran the app test suite locally on the available iPhone 17 simulator destination.
- Unit tests for the new difficulty guide title formatter passed.