### PR TITLE
Add lesson progress routing and JSON-driven theory screens

### DIFF
--- a/SamuiLanguageSchool/ContentView.swift
+++ b/SamuiLanguageSchool/ContentView.swift
@@ -9,41 +9,57 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var path: [Route] = []
+    @StateObject private var progress = ProgressEnvironment()
 
     var body: some View {
         NavigationStack(path: $path) {
             StartView {
-                path.append(.lesson)
+                path.append(.lesson(progress.currentLessonID))
             }
             .navigationDestination(for: Route.self) { route in
                 switch route {
-                case .lesson:
+                case .lesson(let lessonID):
                     LessonView(
+                        viewModel: LessonViewModel(lessonID: lessonID),
                         onBack: pop,
-                        onStartPractice: { path.append(.practice) }
+                        onStartOrContinue: navigateToProgressDestination
                     )
-                case .theory:
+                case .theory(let lessonID, let sectionID):
                     TheoryView(
+                        lessonID: lessonID,
+                        sectionID: sectionID,
                         onBack: pop,
-                        onStartPractice: { path.append(.practice) }
+                        onStartPractice: { taskID in
+                            path.append(.practice(lessonID: lessonID, taskID: taskID))
+                        }
                     )
-                case .practice:
-                    PracticeView(onBack: pop)
+                case .practice(let lessonID, let taskID):
+                    PracticeView(lessonID: lessonID, taskID: taskID, onBack: pop)
                 }
             }
         }
+        .environmentObject(progress)
     }
 
     private func pop() {
         guard !path.isEmpty else { return }
         path.removeLast()
     }
+
+    private func navigateToProgressDestination(lesson: LessonContentModel, destination: ProgressEnvironment.Destination) {
+        switch destination {
+        case .theory(let sectionID):
+            path.append(.theory(lessonID: lesson.id, sectionID: sectionID))
+        case .practice(let taskID):
+            path.append(.practice(lessonID: lesson.id, taskID: taskID))
+        }
+    }
 }
 
 private enum Route: Hashable {
-    case lesson
-    case theory
-    case practice
+    case lesson(String?)
+    case theory(lessonID: String, sectionID: String)
+    case practice(lessonID: String, taskID: String?)
 }
 
 #Preview {

--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -8,19 +8,20 @@
 import SwiftUI
 
 struct LessonView: View {
+    @EnvironmentObject private var progress: ProgressEnvironment
     @StateObject private var viewModel: LessonViewModel
 
     var onBack: () -> Void
-    var onStartPractice: () -> Void
+    var onStartOrContinue: (LessonContentModel, ProgressEnvironment.Destination) -> Void
 
     init(
         viewModel: @autoclosure @escaping () -> LessonViewModel = LessonViewModel(),
         onBack: @escaping () -> Void,
-        onStartPractice: @escaping () -> Void
+        onStartOrContinue: @escaping (LessonContentModel, ProgressEnvironment.Destination) -> Void
     ) {
         _viewModel = StateObject(wrappedValue: viewModel())
         self.onBack = onBack
-        self.onStartPractice = onStartPractice
+        self.onStartOrContinue = onStartOrContinue
     }
 
     var body: some View {
@@ -35,12 +36,29 @@ struct LessonView: View {
             }
 
             SLSBottomActionBar(
-                title: viewModel.primaryPracticeLabel,
+                title: primaryActionTitle,
                 isEnabled: viewModel.lesson != nil,
-                action: onStartPractice
+                action: startOrContinue
             )
         }
         .navigationBarBackButtonHidden()
+    }
+
+    private var primaryActionTitle: String {
+        guard let lesson = viewModel.lesson else {
+            return "Start"
+        }
+
+        return progress.actionTitle(for: lesson)
+    }
+
+    private func startOrContinue() {
+        guard let lesson = viewModel.lesson,
+              let destination = progress.startOrContinueDestination(for: lesson) else {
+            return
+        }
+
+        onStartOrContinue(lesson, destination)
     }
 
     @ViewBuilder
@@ -368,5 +386,6 @@ private struct SectionHeader: View {
 }
 
 #Preview {
-    LessonView(onBack: {}, onStartPractice: {})
+    LessonView(onBack: {}, onStartOrContinue: { _, _ in })
+        .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -8,10 +8,19 @@
 import SwiftUI
 
 struct PracticeView: View {
+    @EnvironmentObject private var progress: ProgressEnvironment
+    let lessonID: String?
+    let taskID: String?
     var onBack: () -> Void
     @State private var selectedAnswer: String?
 
     private let answers = ["go", "went", "goes", "going"]
+
+    init(lessonID: String? = nil, taskID: String? = nil, onBack: @escaping () -> Void) {
+        self.lessonID = lessonID
+        self.taskID = taskID
+        self.onBack = onBack
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -58,6 +67,10 @@ struct PracticeView: View {
             .padding(.bottom, 34)
         }
         .navigationBarBackButtonHidden()
+        .onAppear {
+            guard let lessonID else { return }
+            progress.updatePracticeProgress(lessonID: lessonID, taskID: taskID)
+        }
     }
 
     private var practiceHeader: some View {
@@ -120,4 +133,5 @@ private struct AnswerOptionButton: View {
 
 #Preview {
     PracticeView(onBack: {})
+        .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Features/Theory/TheoryView.swift
+++ b/SamuiLanguageSchool/Features/Theory/TheoryView.swift
@@ -8,8 +8,24 @@
 import SwiftUI
 
 struct TheoryView: View {
+    @EnvironmentObject private var progress: ProgressEnvironment
+    @StateObject private var viewModel: LessonViewModel
+
+    private let requestedSectionID: String
     var onBack: () -> Void
-    var onStartPractice: () -> Void
+    var onStartPractice: (String?) -> Void
+
+    init(
+        lessonID: String,
+        sectionID: String,
+        onBack: @escaping () -> Void,
+        onStartPractice: @escaping (String?) -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: LessonViewModel(lessonID: lessonID))
+        self.requestedSectionID = sectionID
+        self.onBack = onBack
+        self.onStartPractice = onStartPractice
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -19,85 +35,135 @@ struct TheoryView: View {
             VStack(spacing: 0) {
                 SLSTopBar(title: "Theory", backAction: onBack)
 
-                ScrollView(showsIndicators: false) {
-                    VStack(spacing: 28) {
-                        LessonHeroCard()
-                        formationCard
-                        usageCard
-                    }
-                    .padding(.horizontal, SLSSpacing.lg)
-                    .padding(.top, 28)
-                    .padding(.bottom, 130)
-                }
+                content
             }
 
-            SLSBottomActionBar(title: "Start Practice", action: onStartPractice)
+            if let lesson = viewModel.lesson, let section = selectedSection(in: lesson) {
+                SLSBottomActionBar(
+                    title: practiceTask(in: lesson, for: section)?.title ?? "Start Practice",
+                    isEnabled: !section.tryItTaskIds.isEmpty,
+                    action: { startPractice(lesson: lesson, section: section) }
+                )
+            }
         }
         .navigationBarBackButtonHidden()
+        .onAppear(perform: syncProgress)
     }
 
-    private var formationCard: some View {
-        SLSCard(padding: 28) {
-            VStack(alignment: .leading, spacing: SLSSpacing.lg) {
-                Text("Formation")
-                    .font(SLSTypography.sectionTitle)
-                    .foregroundStyle(SLSColors.textPrimary)
-
-                LessonInfoPanel(
-                    title: "Regular verbs",
-                    formula: "Verb + -ed",
-                    highlightedPart: "-ed",
-                    example: "Example: work -> worked, play -> played",
-                    background: SLSColors.lessonSurface
-                )
-
-                LessonInfoPanel(
-                    title: "Irregular verbs",
-                    formula: "Special forms",
-                    highlightedPart: nil,
-                    example: "Example: go -> went, see -> saw",
-                    background: SLSColors.lessonSurface
-                )
-            }
+    @ViewBuilder
+    private var content: some View {
+        if let lesson = viewModel.lesson, let section = selectedSection(in: lesson) {
+            theoryContent(lesson: lesson, section: section)
+        } else {
+            errorContent
         }
     }
 
-    private var usageCard: some View {
-        SLSCard(padding: 28) {
-            VStack(alignment: .leading, spacing: SLSSpacing.md) {
-                Text("Usage")
-                    .font(SLSTypography.sectionTitle)
-                    .foregroundStyle(SLSColors.textPrimary)
-                Text("Use the past simple for finished actions in the past.")
-                    .font(SLSTypography.body)
-                    .foregroundStyle(SLSColors.textSecondary)
+    private func theoryContent(lesson: LessonContentModel, section: LessonContentModel.TheorySection) -> some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 22) {
+                TheoryHeroCard(summary: lesson.screenSummary, section: section, lessonTitle: lesson.title)
+
+                ForEach(Array(section.contentBlocks.enumerated()), id: \.offset) { _, block in
+                    TheoryContentBlockView(block: block)
+                }
             }
+            .padding(.horizontal, SLSSpacing.lg)
+            .padding(.top, 24)
+            .padding(.bottom, 130)
         }
+    }
+
+    private var errorContent: some View {
+        VStack(spacing: SLSSpacing.lg) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+
+            Text("Theory unavailable")
+                .font(SLSTypography.sectionTitle)
+                .foregroundStyle(SLSColors.textPrimary)
+
+            Text(viewModel.errorMessage ?? "Could not load this theory section.")
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(SLSSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func selectedSection(in lesson: LessonContentModel) -> LessonContentModel.TheorySection? {
+        lesson.theorySections.first { $0.id == requestedSectionID } ?? lesson.firstTheorySection
+    }
+
+    private func practiceTask(
+        in lesson: LessonContentModel,
+        for section: LessonContentModel.TheorySection
+    ) -> LessonContentModel.PracticeTask? {
+        guard let taskID = section.tryItTaskIds.first else {
+            return nil
+        }
+
+        return lesson.practiceTasks.first { $0.id == taskID }
+    }
+
+    private func syncProgress() {
+        guard let lesson = viewModel.lesson, let section = selectedSection(in: lesson) else {
+            return
+        }
+
+        progress.updateTheoryProgress(lessonID: lesson.id, sectionID: section.id)
+    }
+
+    private func startPractice(lesson: LessonContentModel, section: LessonContentModel.TheorySection) {
+        let taskID = section.tryItTaskIds.first
+        progress.updateTheoryProgress(lessonID: lesson.id, sectionID: section.id)
+        progress.updatePracticeProgress(lessonID: lesson.id, taskID: taskID)
+        onStartPractice(taskID)
     }
 }
 
-private struct LessonHeroCard: View {
+private struct TheoryHeroCard: View {
+    let summary: LessonContentModel.ScreenSummary
+    let section: LessonContentModel.TheorySection
+    let lessonTitle: String
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 30) {
-            HStack {
-                SLSPill(title: "Lesson 3", foreground: .white, background: .white.opacity(0.22))
-                Spacer()
-                Text("15 min read")
+        VStack(alignment: .leading, spacing: 28) {
+            HStack(alignment: .top) {
+                SLSPill(
+                    title: "Section \(section.order)",
+                    foreground: .white,
+                    background: .white.opacity(0.22)
+                )
+
+                Spacer(minLength: SLSSpacing.sm)
+
+                Text(summary.estimatedReadTimeLabel)
                     .font(SLSTypography.caption)
                     .foregroundStyle(.white)
+                    .padding(.horizontal, 13)
+                    .padding(.vertical, 7)
+                    .background(.white.opacity(0.18))
+                    .clipShape(Capsule())
             }
 
-            VStack(alignment: .leading, spacing: 16) {
-                Text("Past Simple Tense")
+            VStack(alignment: .leading, spacing: 14) {
+                Text(section.title)
                     .font(.system(size: 31, weight: .bold))
                     .foregroundStyle(.white)
-                Text("Regular and irregular verbs")
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(lessonTitle)
                     .font(SLSTypography.heroSubtitle)
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(.white.opacity(0.92))
+                    .lineSpacing(5)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(28)
-        .frame(maxWidth: .infinity, minHeight: 190, alignment: .leading)
+        .padding(26)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             LinearGradient(
                 colors: [SLSColors.orange, SLSColors.brandStrong],
@@ -109,45 +175,439 @@ private struct LessonHeroCard: View {
     }
 }
 
-private struct LessonInfoPanel: View {
-    let title: String
-    let formula: String
-    let highlightedPart: String?
-    let example: String
-    let background: Color
+private struct TheoryContentBlockView: View {
+    let block: LessonContentModel.ContentBlock
 
     var body: some View {
-        VStack(alignment: .leading, spacing: SLSSpacing.md) {
-            Text(title)
-                .font(SLSTypography.body)
-                .foregroundStyle(Color(hex: 0x475467))
-
-            formulaText
-                .font(SLSTypography.bodyStrong)
-                .foregroundStyle(SLSColors.textPrimary)
-
-            Text(example)
-                .font(.system(size: 18, weight: .regular))
-                .foregroundStyle(SLSColors.textSecondary)
-                .lineSpacing(5)
+        switch block.type {
+        case .paragraph:
+            TextBlockView(block: block)
+        case .ruleList, .checklist, .comparison:
+            ListBlockView(block: block)
+        case .formula:
+            FormulaBlockView(block: block)
+        case .example, .exampleList:
+            ExampleBlockView(block: block)
+        case .table:
+            TableBlockView(block: block)
+        case .callout:
+            CalloutBlockView(block: block)
+        case .modelText:
+            ModelTextBlockView(block: block)
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(background)
-        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+}
+
+private struct TextBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 12) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                Text(block.text ?? "")
+                    .font(SLSTypography.body)
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .lineSpacing(5)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+private struct FormulaBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 14) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                Text(block.formula ?? "")
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(SLSColors.brandStrong)
+                    .lineSpacing(6)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(18)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(SLSColors.lessonSurface)
+                    .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+            }
+        }
+    }
+}
+
+private struct ListBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    private var items: [String] {
+        block.items ?? block.examples ?? []
     }
 
-    private var formulaText: Text {
-        guard let highlightedPart, let range = formula.range(of: highlightedPart) else {
-            return Text(formula)
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 16) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                VStack(alignment: .leading, spacing: 13) {
+                    ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                        TheoryBulletRow(text: item)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ExampleBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    private var examples: [String] {
+        block.examples ?? block.items ?? []
+    }
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 16) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                if let text = block.text {
+                    Text(text)
+                        .font(SLSTypography.body)
+                        .foregroundStyle(SLSColors.textPrimary)
+                        .lineSpacing(5)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if !examples.isEmpty {
+                    VStack(alignment: .leading, spacing: 13) {
+                        ForEach(Array(examples.enumerated()), id: \.offset) { _, example in
+                            TheoryBulletRow(text: example)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct TableBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    private var columns: [String] {
+        block.columns ?? []
+    }
+
+    private var rows: [[String: JSONValue]] {
+        block.rows ?? []
+    }
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 16) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        HStack(spacing: 0) {
+                            ForEach(columns, id: \.self) { column in
+                                TableCell(text: column, isHeader: true)
+                            }
+                        }
+
+                        ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, row in
+                            HStack(spacing: 0) {
+                                ForEach(columns, id: \.self) { column in
+                                    TableCell(
+                                        text: TableValueResolver.value(for: column, in: row),
+                                        isHeader: false
+                                    )
+                                }
+                            }
+                            .background(rowIndex.isMultiple(of: 2) ? SLSColors.surface : SLSColors.lessonSurface.opacity(0.55))
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous)
+                            .stroke(SLSColors.border, lineWidth: 1)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct CalloutBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 15) {
+                HStack(spacing: SLSSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(SLSColors.brand)
+
+                    TheoryBlockTitle(block.title ?? block.calloutType?.readableIdentifier ?? "Note")
+                }
+
+                if let incorrect = block.incorrect {
+                    LabeledCalloutText(label: "Incorrect", text: incorrect, color: Color(hex: 0xB42318))
+                }
+
+                if let correct = block.correct {
+                    LabeledCalloutText(label: "Correct", text: correct, color: Color(hex: 0x027A48))
+                }
+
+                if let explanation = block.explanation {
+                    Text(explanation)
+                        .font(SLSTypography.body)
+                        .foregroundStyle(SLSColors.textPrimary)
+                        .lineSpacing(5)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let items = block.items {
+                    VStack(alignment: .leading, spacing: 13) {
+                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                            TheoryBulletRow(text: item)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ModelTextBlockView: View {
+    let block: LessonContentModel.ContentBlock
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 14) {
+                if let title = block.title {
+                    TheoryBlockTitle(title)
+                }
+
+                Text(block.text ?? "")
+                    .font(SLSTypography.body)
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .lineSpacing(6)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(18)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(SLSColors.lessonSurface)
+                    .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+            }
+        }
+    }
+}
+
+private struct TheoryBlockTitle: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title)
+            .font(SLSTypography.sectionTitle)
+            .foregroundStyle(SLSColors.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct TheoryBulletRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SLSSpacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+                .padding(.top, 3)
+
+            Text(text)
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textPrimary)
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct TableCell: View {
+    let text: String
+    let isHeader: Bool
+
+    var body: some View {
+        Text(text)
+            .font(isHeader ? SLSTypography.bodyStrong : .system(size: 15, weight: .regular))
+            .foregroundStyle(isHeader ? .white : SLSColors.textPrimary)
+            .lineSpacing(4)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(12)
+            .frame(width: 190, alignment: .topLeading)
+            .frame(minHeight: 54, alignment: .topLeading)
+            .background(isHeader ? SLSColors.brand : Color.clear)
+            .overlay(alignment: .trailing) {
+                Rectangle()
+                    .fill(isHeader ? .white.opacity(0.18) : SLSColors.border)
+                    .frame(width: 1)
+            }
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(SLSColors.border)
+                    .frame(height: 1)
+            }
+    }
+}
+
+private struct LabeledCalloutText: View {
+    let label: String
+    let text: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(label)
+                .font(SLSTypography.caption)
+                .foregroundStyle(color)
+
+            Text(text)
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textPrimary)
+                .lineSpacing(5)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
+    }
+}
+
+private enum TableValueResolver {
+    static func value(for column: String, in row: [String: JSONValue]) -> String {
+        let candidates = candidateKeys(for: column)
+
+        for candidate in candidates {
+            if let value = row[candidate] {
+                return value.displayText
+            }
         }
 
-        let prefix = String(formula[..<range.lowerBound])
-        let suffix = String(formula[range.upperBound...])
-        return Text("\(prefix)\(Text(highlightedPart).foregroundColor(SLSColors.brandStrong))\(suffix)")
+        let normalizedColumn = column.normalizedIdentifier
+        if let match = row.first(where: { key, _ in key.normalizedIdentifier == normalizedColumn }) {
+            return match.value.displayText
+        }
+
+        return ""
+    }
+
+    private static func candidateKeys(for column: String) -> [String] {
+        let aliases = [
+            "Article": "article",
+            "Either works but the tone is different?": "linker",
+            "Example": "example",
+            "Example sentence": "example",
+            "Form": "form",
+            "If...not": "ifNot",
+            "Linker": "linker",
+            "Meaning": "meaning",
+            "Pattern": "pattern",
+            "Question": "question",
+            "Reflexive pronoun": "pronoun",
+            "Signal": "signal",
+            "Situation": "situation",
+            "Subject": "subject",
+            "Unless": "unless",
+            "Use": "use",
+            "What it means": "meaning"
+        ]
+
+        return [
+            aliases[column],
+            column.camelCaseIdentifier,
+            column.normalizedIdentifier
+        ]
+        .compactMap { $0 }
+    }
+}
+
+private extension JSONValue {
+    var displayText: String {
+        switch self {
+        case .string(let value):
+            return value
+        case .number(let value):
+            if value.rounded() == value {
+                return String(Int(value))
+            }
+
+            return String(value)
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .object(let values):
+            return values
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key): \($0.value.displayText)" }
+                .joined(separator: "\n")
+        case .array(let values):
+            return values.map(\.displayText).joined(separator: "\n")
+        case .null:
+            return ""
+        }
+    }
+}
+
+private extension String {
+    var camelCaseIdentifier: String {
+        let words = split(whereSeparator: { !$0.isLetter && !$0.isNumber }).map(String.init)
+        guard let first = words.first?.lowercased() else {
+            return self
+        }
+
+        return words.dropFirst().reduce(first) { result, word in
+            result + word.prefix(1).uppercased() + String(word.dropFirst())
+        }
+    }
+
+    var normalizedIdentifier: String {
+        lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    var readableIdentifier: String {
+        unicodeScalars.reduce("") { result, scalar in
+            if CharacterSet.uppercaseLetters.contains(scalar), !result.isEmpty {
+                return result + " " + String(scalar).lowercased()
+            }
+
+            return result + String(scalar)
+        }
+        .capitalized
     }
 }
 
 #Preview {
-    TheoryView(onBack: {}, onStartPractice: {})
+    TheoryView(
+        lessonID: "articles-discourse-part-2",
+        sectionID: "article-tracking-system",
+        onBack: {},
+        onStartPractice: { _ in }
+    )
+    .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Models/ProgressEnvironment.swift
+++ b/SamuiLanguageSchool/Models/ProgressEnvironment.swift
@@ -1,0 +1,84 @@
+//
+//  ProgressEnvironment.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class ProgressEnvironment: ObservableObject {
+    enum Destination: Equatable {
+        case theory(sectionID: String)
+        case practice(taskID: String)
+    }
+
+    @Published var currentLessonID: String?
+    @Published var currentTheorySectionID: String?
+    @Published var currentPracticeTaskID: String?
+
+    init(
+        currentLessonID: String? = "articles-discourse-part-2",
+        currentTheorySectionID: String? = nil,
+        currentPracticeTaskID: String? = nil
+    ) {
+        self.currentLessonID = currentLessonID
+        self.currentTheorySectionID = currentTheorySectionID
+        self.currentPracticeTaskID = currentPracticeTaskID
+    }
+
+    func actionTitle(for lesson: LessonContentModel) -> String {
+        hasProgress(in: lesson) ? "Continue" : "Start"
+    }
+
+    func startOrContinueDestination(for lesson: LessonContentModel) -> Destination? {
+        if currentLessonID != lesson.id {
+            currentLessonID = lesson.id
+            currentTheorySectionID = nil
+            currentPracticeTaskID = nil
+        }
+
+        if let taskID = currentPracticeTaskID {
+            return .practice(taskID: taskID)
+        }
+
+        guard let sectionID = currentTheorySectionID ?? lesson.firstTheorySection?.id else {
+            return nil
+        }
+
+        currentTheorySectionID = sectionID
+        return .theory(sectionID: sectionID)
+    }
+
+    func updateTheoryProgress(lessonID: String, sectionID: String) {
+        currentLessonID = lessonID
+        currentTheorySectionID = sectionID
+    }
+
+    func updatePracticeProgress(lessonID: String, taskID: String?) {
+        currentLessonID = lessonID
+        currentPracticeTaskID = taskID
+    }
+
+    private func hasProgress(in lesson: LessonContentModel) -> Bool {
+        currentLessonID == lesson.id && (currentTheorySectionID != nil || currentPracticeTaskID != nil)
+    }
+}
+
+extension LessonContentModel {
+    var orderedTheorySections: [TheorySection] {
+        theorySections.sorted { lhs, rhs in
+            if lhs.order == rhs.order {
+                return lhs.id < rhs.id
+            }
+
+            return lhs.order < rhs.order
+        }
+    }
+
+    var firstTheorySection: TheorySection? {
+        orderedTheorySections.first
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared progress environment to track the current lesson, theory section, and practice task IDs.
- Update the Lesson CTA to switch between `Start` and `Continue` and route to the current theory section or practice task.
- Rebuild Theory to render a single `theorySections` entry from `lessons.json` using its content blocks instead of hardcoded copy.
- Thread lesson and task identifiers through navigation so Theory and Practice stay aligned with the selected lesson state.

## Testing
- `xcodebuild -project SamuiLanguageSchool.xcodeproj -scheme SamuiLanguageSchool -destination 'generic/platform=iOS Simulator' build`
- `git diff --check`

Resolves #8