### PR TITLE
Load Practice screen from lessons.json and add session flow

### DIFF
--- a/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
@@ -1,0 +1,320 @@
+//
+//  PracticeSessionSupport.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 01.05.2026.
+//
+
+import Foundation
+
+enum PracticeTaskResolver {
+    static func selectedTask(
+        in lesson: LessonContentModel,
+        requestedTaskID: String?
+    ) -> LessonContentModel.PracticeTask? {
+        if let requestedTaskID,
+           let task = lesson.practiceTasks.first(where: { $0.id == requestedTaskID }) {
+            return task
+        }
+
+        return lesson.practiceTasks.first
+    }
+}
+
+struct PracticeEvaluation: Equatable {
+    let state: PracticeEvaluationState
+    let expectedAnswer: String?
+    let explanation: String?
+    let errorType: String?
+    let notes: String?
+    let sampleAnswers: [String]
+
+    var isGradable: Bool {
+        switch state {
+        case .correct, .incorrect:
+            return true
+        case .reviewed:
+            return false
+        }
+    }
+
+    var isCorrect: Bool {
+        state == .correct
+    }
+}
+
+enum PracticeEvaluationState: Equatable {
+    case correct
+    case incorrect
+    case reviewed
+}
+
+enum PracticeAnswerEvaluator {
+    static func evaluate(
+        response: String,
+        for item: LessonContentModel.TaskItem,
+        answerKey: LessonContentModel.AnswerKeyTask?
+    ) -> PracticeEvaluation {
+        if item.type == .sorting {
+            return evaluateSorting(response: response, item: item, answerKey: answerKey)
+        }
+
+        let entry = answerKey?.entries.first { $0.itemId == item.id }
+        guard let entry else {
+            return reviewedEvaluation(entry: nil, taskNotes: answerKey?.teacherNotes)
+        }
+
+        let candidates = answerCandidates(from: entry)
+        guard !candidates.isEmpty else {
+            return reviewedEvaluation(entry: entry, taskNotes: answerKey?.teacherNotes)
+        }
+
+        let normalizedResponse = normalized(response)
+        let isCorrect = candidates.contains { normalized($0) == normalizedResponse }
+
+        return PracticeEvaluation(
+            state: isCorrect ? .correct : .incorrect,
+            expectedAnswer: expectedAnswerText(from: entry),
+            explanation: entry.explanation,
+            errorType: entry.errorType,
+            notes: entry.notes ?? answerKey?.teacherNotes,
+            sampleAnswers: entry.sampleAnswers ?? []
+        )
+    }
+
+    static func isAutoGradable(
+        item: LessonContentModel.TaskItem,
+        answerKey: LessonContentModel.AnswerKeyTask?
+    ) -> Bool {
+        if item.type == .sorting {
+            guard let number = item.number?.sortingNumber,
+                  let categories = item.categories,
+                  let entries = answerKey?.entries,
+                  categories.count <= entries.count else {
+                return false
+            }
+
+            return entries.prefix(categories.count).contains { entry in
+                entry.answer?.integerArrayValue?.contains(number) == true
+            }
+        }
+
+        guard let entry = answerKey?.entries.first(where: { $0.itemId == item.id }) else {
+            return false
+        }
+
+        return !answerCandidates(from: entry).isEmpty
+    }
+
+    static func responseIsPresent(_ response: String?, for item: LessonContentModel.TaskItem) -> Bool {
+        switch item.type {
+        case .speakingPrompt:
+            return true
+        default:
+            return !(response ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    static func expectedAnswerText(
+        from entry: LessonContentModel.AnswerEntry?
+    ) -> String? {
+        guard let entry else {
+            return nil
+        }
+
+        if let object = entry.answer?.objectValue {
+            let error = object["error"]?.displayText
+            let correction = object["correction"]?.displayText
+
+            switch (error, correction) {
+            case let (.some(error), .some(correction)):
+                return "Error: \(error)\nCorrection: \(correction)"
+            case let (nil, .some(correction)):
+                return correction
+            case let (.some(error), nil):
+                return error
+            case (nil, nil):
+                break
+            }
+        }
+
+        if let acceptedAnswers = entry.acceptedAnswers, !acceptedAnswers.isEmpty {
+            return acceptedAnswers.joined(separator: " / ")
+        }
+
+        return entry.answer?.displayText
+    }
+
+    private static func evaluateSorting(
+        response: String,
+        item: LessonContentModel.TaskItem,
+        answerKey: LessonContentModel.AnswerKeyTask?
+    ) -> PracticeEvaluation {
+        guard let number = item.number?.sortingNumber,
+              let categories = item.categories,
+              let selectedCategoryIndex = categories.firstIndex(of: response),
+              let entries = answerKey?.entries,
+              entries.indices.contains(selectedCategoryIndex) else {
+            return reviewedEvaluation(entry: nil, taskNotes: answerKey?.teacherNotes)
+        }
+
+        let selectedEntry = entries[selectedCategoryIndex]
+        let isCorrect = selectedEntry.answer?.integerArrayValue?.contains(number) == true
+
+        return PracticeEvaluation(
+            state: isCorrect ? .correct : .incorrect,
+            expectedAnswer: sortingExpectedAnswer(for: number, categories: categories, entries: entries),
+            explanation: selectedEntry.explanation,
+            errorType: selectedEntry.errorType,
+            notes: selectedEntry.notes ?? answerKey?.teacherNotes,
+            sampleAnswers: selectedEntry.sampleAnswers ?? []
+        )
+    }
+
+    private static func sortingExpectedAnswer(
+        for number: Int,
+        categories: [String],
+        entries: [LessonContentModel.AnswerEntry]
+    ) -> String? {
+        for (index, category) in categories.enumerated() where entries.indices.contains(index) {
+            if entries[index].answer?.integerArrayValue?.contains(number) == true {
+                return category
+            }
+        }
+
+        return nil
+    }
+
+    private static func reviewedEvaluation(
+        entry: LessonContentModel.AnswerEntry?,
+        taskNotes: String?
+    ) -> PracticeEvaluation {
+        PracticeEvaluation(
+            state: .reviewed,
+            expectedAnswer: expectedAnswerText(from: entry),
+            explanation: entry?.explanation,
+            errorType: entry?.errorType,
+            notes: entry?.notes ?? taskNotes,
+            sampleAnswers: entry?.sampleAnswers ?? []
+        )
+    }
+
+    private static func answerCandidates(from entry: LessonContentModel.AnswerEntry) -> [String] {
+        var candidates = entry.acceptedAnswers ?? []
+
+        if let answer = entry.answer {
+            if let correction = answer.objectValue?["correction"]?.displayText {
+                candidates.append(correction)
+            } else {
+                candidates.append(contentsOf: answer.candidateTexts)
+            }
+        }
+
+        return candidates
+    }
+
+    private static func normalized(_ value: String) -> String {
+        let trimmed = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?;:"))
+            .lowercased()
+
+        let collapsedWhitespace = trimmed
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        switch collapsedWhitespace {
+        case "zero article", "zero", "no article", "none":
+            return "zero article"
+        default:
+            return collapsedWhitespace
+        }
+    }
+}
+
+private extension LessonContentNumber {
+    var sortingNumber: Int? {
+        switch self {
+        case .integer(let value):
+            return value
+        case .string(let value):
+            return Int(value)
+        }
+    }
+}
+
+private extension JSONValue {
+    var objectValue: [String: JSONValue]? {
+        guard case .object(let value) = self else {
+            return nil
+        }
+
+        return value
+    }
+
+    var integerArrayValue: [Int]? {
+        guard case .array(let values) = self else {
+            return nil
+        }
+
+        return values.compactMap(\.integerValue)
+    }
+
+    var candidateTexts: [String] {
+        switch self {
+        case .string(let value):
+            return [value]
+        case .number(let value):
+            return [Self.numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"]
+        case .array(let values):
+            return values.flatMap(\.candidateTexts)
+        case .object, .bool, .null:
+            return []
+        }
+    }
+
+    var displayText: String? {
+        switch self {
+        case .string(let value):
+            return value
+        case .number(let value):
+            return Self.numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .array(let values):
+            let displayValues = values.compactMap(\.displayText)
+            return displayValues.isEmpty ? nil : displayValues.joined(separator: " / ")
+        case .object(let object):
+            let displayValues = object
+                .sorted { $0.key < $1.key }
+                .compactMap { key, value -> String? in
+                    guard let displayText = value.displayText else {
+                        return nil
+                    }
+                    return "\(key): \(displayText)"
+                }
+            return displayValues.isEmpty ? nil : displayValues.joined(separator: "\n")
+        case .null:
+            return nil
+        }
+    }
+
+    private var integerValue: Int? {
+        switch self {
+        case .number(let value):
+            return Int(value)
+        case .string(let value):
+            return Int(value)
+        case .bool, .object, .array, .null:
+            return nil
+        }
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        return formatter
+    }()
+}

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -9,16 +9,22 @@ import SwiftUI
 
 struct PracticeView: View {
     @EnvironmentObject private var progress: ProgressEnvironment
-    let lessonID: String?
-    let taskID: String?
-    var onBack: () -> Void
-    @State private var selectedAnswer: String?
+    @StateObject private var viewModel: LessonViewModel
 
-    private let answers = ["go", "went", "goes", "going"]
+    private let requestedTaskID: String?
+    private let providedLessonID: String?
+    var onBack: () -> Void
+
+    @State private var activeTaskID: String?
+    @State private var currentItemIndex = 0
+    @State private var responses: [String: String] = [:]
+    @State private var evaluations: [String: PracticeEvaluation] = [:]
+    @State private var isComplete = false
 
     init(lessonID: String? = nil, taskID: String? = nil, onBack: @escaping () -> Void) {
-        self.lessonID = lessonID
-        self.taskID = taskID
+        _viewModel = StateObject(wrappedValue: LessonViewModel(lessonID: lessonID))
+        self.providedLessonID = lessonID
+        self.requestedTaskID = taskID
         self.onBack = onBack
     }
 
@@ -28,58 +34,38 @@ struct PracticeView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                practiceHeader
+                if let lesson = viewModel.lesson, let task = selectedTask(in: lesson) {
+                    practiceHeader(task: task)
 
-                VStack(alignment: .leading, spacing: 30) {
-                    SLSPill(title: "Question 1")
-
-                    questionText
-
-                    VStack(spacing: SLSSpacing.md) {
-                        ForEach(answers, id: \.self) { answer in
-                            AnswerOptionButton(
-                                title: answer,
-                                isSelected: selectedAnswer == answer
-                            ) {
-                                selectedAnswer = answer
-                            }
-                        }
+                    if isComplete {
+                        completionContent(task: task)
+                    } else {
+                        practiceContent(lesson: lesson, task: task)
                     }
-
-                    Spacer(minLength: 110)
+                } else {
+                    SLSTopBar(title: "Practice", backAction: onBack)
+                    errorContent
                 }
-                .padding(.horizontal, SLSSpacing.lg)
-                .padding(.top, 40)
             }
 
-            Button(action: {}) {
-                Text("Check Answer")
-                    .font(SLSTypography.button)
-                    .foregroundStyle(selectedAnswer == nil ? SLSColors.textTertiary : .white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 68)
-                    .background(selectedAnswer == nil ? SLSColors.disabledFill : SLSColors.brand)
-                    .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+            if let lesson = viewModel.lesson,
+               let task = selectedTask(in: lesson),
+               let item = currentItem(in: task),
+               !isComplete {
+                bottomActionBar(lesson: lesson, task: task, item: item)
             }
-            .buttonStyle(.plain)
-            .disabled(selectedAnswer == nil)
-            .padding(.horizontal, SLSSpacing.lg)
-            .padding(.bottom, 34)
         }
         .navigationBarBackButtonHidden()
-        .onAppear {
-            guard let lessonID else { return }
-            progress.updatePracticeProgress(lessonID: lessonID, taskID: taskID)
-        }
+        .onAppear(perform: syncProgress)
     }
 
-    private var practiceHeader: some View {
+    private func practiceHeader(task: LessonContentModel.PracticeTask) -> some View {
         VStack(spacing: 0) {
             SLSTopBar(title: "Practice", backAction: onBack, showsSeparator: false)
 
             HStack(spacing: SLSSpacing.md) {
-                SLSProgressBar(value: 0.2)
-                Text("1/5")
+                SLSProgressBar(value: progressValue(for: task))
+                Text(progressText(for: task))
                     .font(.system(size: 19, weight: .regular))
                     .foregroundStyle(SLSColors.textSecondary)
             }
@@ -95,31 +81,530 @@ struct PracticeView: View {
         }
     }
 
-    private var questionText: some View {
-        Text("I \(Text("___").foregroundStyle(SLSColors.brand)) to the cinema last\nnight.")
-            .font(SLSTypography.question)
-            .foregroundStyle(SLSColors.textPrimary)
-            .lineSpacing(10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .fixedSize(horizontal: false, vertical: true)
+    private func practiceContent(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask
+    ) -> some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 22) {
+                taskIntroCard(task: task)
+
+                if let item = currentItem(in: task) {
+                    itemCard(item: item, task: task, answerKey: answerKey(in: lesson, for: task))
+                }
+            }
+            .padding(.horizontal, SLSSpacing.lg)
+            .padding(.top, 24)
+            .padding(.bottom, 130)
+        }
     }
+
+    private func taskIntroCard(task: LessonContentModel.PracticeTask) -> some View {
+        SLSCard {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(alignment: .top, spacing: SLSSpacing.sm) {
+                    SLSPill(title: task.sourceLabel ?? task.kind.title)
+
+                    Spacer(minLength: SLSSpacing.sm)
+
+                    if let metaText = taskMetaText(task) {
+                        Text(metaText)
+                            .font(SLSTypography.caption)
+                            .foregroundStyle(SLSColors.textSecondary)
+                    }
+                }
+
+                Text(task.title)
+                    .font(SLSTypography.cardTitle)
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(task.instructions)
+                    .font(SLSTypography.body)
+                    .foregroundStyle(SLSColors.textSecondary)
+                    .lineSpacing(4)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let stimulus = task.stimulus {
+                    Text(stimulus)
+                        .font(SLSTypography.body)
+                        .foregroundStyle(SLSColors.textPrimary)
+                        .lineSpacing(5)
+                        .padding(16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(SLSColors.lessonSurface)
+                        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+                }
+
+                if let supportingPrompts = task.supportingPrompts {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(supportingPrompts, id: \.self) { prompt in
+                            PracticeBulletRow(text: prompt)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func itemCard(
+        item: LessonContentModel.TaskItem,
+        task: LessonContentModel.PracticeTask,
+        answerKey: LessonContentModel.AnswerKeyTask?
+    ) -> some View {
+        SLSCard {
+            VStack(alignment: .leading, spacing: 22) {
+                HStack(alignment: .top) {
+                    SLSPill(title: itemLabel(for: item, index: currentItemIndex))
+                    Spacer(minLength: SLSSpacing.sm)
+                    Text(item.type.title)
+                        .font(SLSTypography.caption)
+                        .foregroundStyle(SLSColors.textSecondary)
+                }
+
+                if let context = item.context {
+                    Text(context)
+                        .font(SLSTypography.body)
+                        .foregroundStyle(SLSColors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(item.prompt)
+                    .font(.system(size: 25, weight: .bold))
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .lineSpacing(7)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let original = item.original {
+                    PracticeDetailBlock(title: "Original", text: original)
+                }
+
+                if let text = item.text {
+                    PracticeDetailBlock(title: "Text", text: text)
+                }
+
+                itemHints(item)
+                responseInput(for: item)
+
+                if let evaluation = evaluations[item.id] {
+                    feedbackCard(evaluation: evaluation)
+                } else if !PracticeAnswerEvaluator.isAutoGradable(item: item, answerKey: answerKey),
+                          let teacherNotes = answerKey?.teacherNotes {
+                    PracticeDetailBlock(title: "Teacher Notes", text: teacherNotes)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func itemHints(_ item: LessonContentModel.TaskItem) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let answerType = item.answerType {
+                PracticeBulletRow(text: "Answer type: \(answerType)")
+            }
+
+            if let targetForm = item.targetForm {
+                PracticeBulletRow(text: "Target: \(targetForm)")
+            }
+
+            if let targetForms = item.targetForms {
+                ForEach(targetForms, id: \.self) { targetForm in
+                    PracticeBulletRow(text: "Target: \(targetForm)")
+                }
+            }
+
+            if let newSubject = item.newSubject {
+                PracticeBulletRow(text: "New subject: \(newSubject)")
+            }
+
+            if let checklist = item.checklist {
+                ForEach(checklist, id: \.self) { checklistItem in
+                    PracticeBulletRow(text: checklistItem)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func responseInput(for item: LessonContentModel.TaskItem) -> some View {
+        switch item.type {
+        case .multipleChoice, .labeling:
+            optionList(options: item.options ?? [], item: item)
+        case .sorting:
+            optionList(options: item.categories ?? [], item: item)
+        case .speakingPrompt:
+            SpeakingCompletionCard(isComplete: evaluations[item.id] != nil)
+        case .paragraphWriting, .freeResponse:
+            textEditor(for: item, minHeight: 150)
+        case .gapFill, .rewrite, .errorCorrection, .tableCompletion:
+            textEditor(for: item, minHeight: 92)
+        }
+    }
+
+    private func optionList(options: [String], item: LessonContentModel.TaskItem) -> some View {
+        VStack(spacing: SLSSpacing.md) {
+            ForEach(options, id: \.self) { option in
+                AnswerOptionButton(
+                    title: option,
+                    isSelected: responses[item.id] == option,
+                    isDisabled: evaluations[item.id] != nil
+                ) {
+                    responses[item.id] = option
+                }
+            }
+        }
+    }
+
+    private func textEditor(for item: LessonContentModel.TaskItem, minHeight: CGFloat) -> some View {
+        TextEditor(text: responseBinding(for: item))
+            .font(SLSTypography.body)
+            .foregroundStyle(SLSColors.textPrimary)
+            .frame(minHeight: minHeight)
+            .padding(12)
+            .scrollContentBackground(.hidden)
+            .background(SLSColors.background)
+            .overlay {
+                RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous)
+                    .stroke(SLSColors.border, lineWidth: 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+            .disabled(evaluations[item.id] != nil)
+    }
+
+    private func feedbackCard(evaluation: PracticeEvaluation) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: feedbackIcon(for: evaluation))
+                    .font(.system(size: 20, weight: .semibold))
+
+                Text(feedbackTitle(for: evaluation))
+                    .font(SLSTypography.bodyStrong)
+            }
+            .foregroundStyle(feedbackColor(for: evaluation))
+
+            if let expectedAnswer = evaluation.expectedAnswer {
+                PracticeDetailBlock(title: "Answer", text: expectedAnswer)
+            }
+
+            if let explanation = evaluation.explanation {
+                PracticeDetailBlock(title: "Explanation", text: explanation)
+            }
+
+            if let errorType = evaluation.errorType {
+                PracticeDetailBlock(title: "Focus", text: errorType)
+            }
+
+            if !evaluation.sampleAnswers.isEmpty {
+                PracticeDetailBlock(title: "Samples", text: evaluation.sampleAnswers.joined(separator: "\n"))
+            }
+
+            if let notes = evaluation.notes {
+                PracticeDetailBlock(title: "Notes", text: notes)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(feedbackColor(for: evaluation).opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+
+    private func completionContent(task: LessonContentModel.PracticeTask) -> some View {
+        VStack(spacing: 22) {
+            Spacer(minLength: 40)
+
+            SLSCard {
+                VStack(alignment: .leading, spacing: 20) {
+                    SLSPill(title: "Complete")
+
+                    Text(task.title)
+                        .font(SLSTypography.cardTitle)
+                        .foregroundStyle(SLSColors.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(summaryText(for: task))
+                        .font(SLSTypography.body)
+                        .foregroundStyle(SLSColors.textSecondary)
+                        .lineSpacing(5)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    SLSPrimaryButton(title: "Done", action: onBack)
+                }
+            }
+            .padding(.horizontal, SLSSpacing.lg)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var errorContent: some View {
+        VStack(spacing: SLSSpacing.lg) {
+            Image(systemName: "questionmark.app.dashed")
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+
+            Text("Practice unavailable")
+                .font(SLSTypography.sectionTitle)
+                .foregroundStyle(SLSColors.textPrimary)
+
+            Text(viewModel.errorMessage ?? "Could not load this practice task.")
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(SLSSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func bottomActionBar(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask,
+        item: LessonContentModel.TaskItem
+    ) -> some View {
+        let actionState = bottomActionState(lesson: lesson, task: task, item: item)
+
+        return SLSBottomActionBar(
+            title: actionState.title,
+            isEnabled: actionState.isEnabled,
+            action: { performBottomAction(actionState.action, lesson: lesson, task: task, item: item) }
+        )
+    }
+
+    private func bottomActionState(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask,
+        item: LessonContentModel.TaskItem
+    ) -> PracticeBottomActionState {
+        if evaluations[item.id] != nil {
+            return PracticeBottomActionState(
+                title: isLastItem(in: task) ? "Finish" : "Next",
+                isEnabled: true,
+                action: .advance
+            )
+        }
+
+        let answerKey = answerKey(in: lesson, for: task)
+        let isAutoGradable = PracticeAnswerEvaluator.isAutoGradable(item: item, answerKey: answerKey)
+        let hasResponse = PracticeAnswerEvaluator.responseIsPresent(responses[item.id], for: item)
+
+        return PracticeBottomActionState(
+            title: isAutoGradable ? "Check Answer" : openEndedActionTitle(for: item),
+            isEnabled: hasResponse,
+            action: .evaluate
+        )
+    }
+
+    private func performBottomAction(
+        _ action: PracticeBottomAction,
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask,
+        item: LessonContentModel.TaskItem
+    ) {
+        switch action {
+        case .evaluate:
+            let response = responses[item.id] ?? ""
+            evaluations[item.id] = PracticeAnswerEvaluator.evaluate(
+                response: response,
+                for: item,
+                answerKey: answerKey(in: lesson, for: task)
+            )
+        case .advance:
+            if isLastItem(in: task) {
+                isComplete = true
+            } else {
+                currentItemIndex = min(currentItemIndex + 1, task.items.count - 1)
+            }
+        }
+    }
+
+    private func selectedTask(in lesson: LessonContentModel) -> LessonContentModel.PracticeTask? {
+        PracticeTaskResolver.selectedTask(in: lesson, requestedTaskID: requestedTaskID)
+    }
+
+    private func answerKey(
+        in lesson: LessonContentModel,
+        for task: LessonContentModel.PracticeTask
+    ) -> LessonContentModel.AnswerKeyTask? {
+        lesson.answerKey.first { $0.taskId == task.id }
+    }
+
+    private func currentItem(in task: LessonContentModel.PracticeTask) -> LessonContentModel.TaskItem? {
+        guard !task.items.isEmpty else {
+            return nil
+        }
+
+        return task.items[min(currentItemIndex, task.items.count - 1)]
+    }
+
+    private func syncProgress() {
+        guard let lesson = viewModel.lesson, let task = selectedTask(in: lesson) else {
+            return
+        }
+
+        if activeTaskID != task.id {
+            resetSession(for: task)
+        }
+
+        progress.updatePracticeProgress(lessonID: providedLessonID ?? lesson.id, taskID: task.id)
+    }
+
+    private func resetSession(for task: LessonContentModel.PracticeTask) {
+        activeTaskID = task.id
+        currentItemIndex = 0
+        responses = [:]
+        evaluations = [:]
+        isComplete = task.items.isEmpty
+    }
+
+    private func responseBinding(for item: LessonContentModel.TaskItem) -> Binding<String> {
+        Binding {
+            responses[item.id] ?? ""
+        } set: { newValue in
+            responses[item.id] = newValue
+        }
+    }
+
+    private func progressValue(for task: LessonContentModel.PracticeTask) -> Double {
+        guard !task.items.isEmpty else {
+            return 1
+        }
+
+        if isComplete {
+            return 1
+        }
+
+        return Double(currentItemIndex + 1) / Double(task.items.count)
+    }
+
+    private func progressText(for task: LessonContentModel.PracticeTask) -> String {
+        guard !task.items.isEmpty else {
+            return "0/0"
+        }
+
+        if isComplete {
+            return "\(task.items.count)/\(task.items.count)"
+        }
+
+        return "\(currentItemIndex + 1)/\(task.items.count)"
+    }
+
+    private func itemLabel(for item: LessonContentModel.TaskItem, index: Int) -> String {
+        if let numberText = item.number?.displayText {
+            return "Question \(numberText)"
+        }
+
+        return "Question \(index + 1)"
+    }
+
+    private func taskMetaText(_ task: LessonContentModel.PracticeTask) -> String? {
+        var parts: [String] = []
+
+        if let difficulty = task.difficulty, !difficulty.isEmpty {
+            parts.append(difficulty)
+        }
+
+        if let estimatedMinutes = task.estimatedMinutes {
+            parts.append("\(estimatedMinutes.min)-\(estimatedMinutes.max) min")
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " | ")
+    }
+
+    private func isLastItem(in task: LessonContentModel.PracticeTask) -> Bool {
+        currentItemIndex >= task.items.count - 1
+    }
+
+    private func openEndedActionTitle(for item: LessonContentModel.TaskItem) -> String {
+        switch item.type {
+        case .speakingPrompt:
+            return "Mark Complete"
+        case .freeResponse, .paragraphWriting:
+            return "Show Answer"
+        case .gapFill, .multipleChoice, .rewrite, .sorting, .labeling, .errorCorrection, .tableCompletion:
+            return "Show Answer"
+        }
+    }
+
+    private func feedbackTitle(for evaluation: PracticeEvaluation) -> String {
+        switch evaluation.state {
+        case .correct:
+            return "Correct"
+        case .incorrect:
+            return "Try again next time"
+        case .reviewed:
+            return "Review"
+        }
+    }
+
+    private func feedbackIcon(for evaluation: PracticeEvaluation) -> String {
+        switch evaluation.state {
+        case .correct:
+            return "checkmark.circle.fill"
+        case .incorrect:
+            return "xmark.circle.fill"
+        case .reviewed:
+            return "text.bubble.fill"
+        }
+    }
+
+    private func feedbackColor(for evaluation: PracticeEvaluation) -> Color {
+        switch evaluation.state {
+        case .correct:
+            return Color(hex: 0x18864B)
+        case .incorrect:
+            return Color(hex: 0xC2410C)
+        case .reviewed:
+            return SLSColors.brand
+        }
+    }
+
+    private func summaryText(for task: LessonContentModel.PracticeTask) -> String {
+        let completedCount = evaluations.count
+        let gradableEvaluations = evaluations.values.filter(\.isGradable)
+        let correctCount = gradableEvaluations.filter(\.isCorrect).count
+
+        if gradableEvaluations.isEmpty {
+            return "Completed \(completedCount) of \(task.items.count) items. This task is teacher-assessed, so it is not included in the score."
+        }
+
+        return "Completed \(completedCount) of \(task.items.count) items.\nScore: \(correctCount) of \(gradableEvaluations.count) auto-graded items."
+    }
+}
+
+private struct PracticeBottomActionState {
+    let title: String
+    let isEnabled: Bool
+    let action: PracticeBottomAction
+}
+
+private enum PracticeBottomAction {
+    case evaluate
+    case advance
 }
 
 private struct AnswerOptionButton: View {
     let title: String
     let isSelected: Bool
+    var isDisabled = false
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            HStack {
+            HStack(spacing: SLSSpacing.md) {
                 Text(title)
                     .font(SLSTypography.bodyStrong)
                     .foregroundStyle(SLSColors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
                 Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(SLSColors.brand)
+                }
             }
             .padding(.horizontal, 22)
-            .frame(height: 74)
+            .padding(.vertical, 18)
+            .frame(maxWidth: .infinity, minHeight: 66, alignment: .leading)
             .background(SLSColors.surface)
             .overlay {
                 RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous)
@@ -128,10 +613,122 @@ private struct AnswerOptionButton: View {
             .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
         }
         .buttonStyle(.plain)
+        .disabled(isDisabled)
+    }
+}
+
+private struct PracticeDetailBlock: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(SLSTypography.caption)
+                .foregroundStyle(SLSColors.textSecondary)
+            Text(text)
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textPrimary)
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct PracticeBulletRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Circle()
+                .fill(SLSColors.brand)
+                .frame(width: 6, height: 6)
+
+            Text(text)
+                .font(SLSTypography.body)
+                .foregroundStyle(SLSColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct SpeakingCompletionCard: View {
+    let isComplete: Bool
+
+    var body: some View {
+        HStack(spacing: SLSSpacing.md) {
+            Image(systemName: isComplete ? "checkmark.circle.fill" : "mic.circle.fill")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+
+            Text(isComplete ? "Completed" : "Ready for speaking practice")
+                .font(SLSTypography.bodyStrong)
+                .foregroundStyle(SLSColors.textPrimary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SLSColors.lessonSurface)
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+}
+
+private extension LessonContentNumber {
+    var displayText: String {
+        switch self {
+        case .integer(let value):
+            return "\(value)"
+        case .string(let value):
+            return value
+        }
+    }
+}
+
+private extension LessonContentModel.TaskItemType {
+    var title: String {
+        switch self {
+        case .gapFill:
+            return "Gap fill"
+        case .multipleChoice:
+            return "Multiple choice"
+        case .rewrite:
+            return "Rewrite"
+        case .sorting:
+            return "Sorting"
+        case .labeling:
+            return "Labeling"
+        case .errorCorrection:
+            return "Error correction"
+        case .tableCompletion:
+            return "Table"
+        case .paragraphWriting:
+            return "Writing"
+        case .speakingPrompt:
+            return "Speaking"
+        case .freeResponse:
+            return "Free response"
+        }
+    }
+}
+
+private extension LessonContentModel.PracticeTaskKind {
+    var title: String {
+        switch self {
+        case .tryIt:
+            return "Try It"
+        case .activity:
+            return "Activity"
+        case .warmUp:
+            return "Warm Up"
+        }
     }
 }
 
 #Preview {
-    PracticeView(onBack: {})
-        .environmentObject(ProgressEnvironment())
+    PracticeView(
+        lessonID: "articles-discourse-part-2",
+        taskID: "articles-try-it-a",
+        onBack: {}
+    )
+    .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
+++ b/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
@@ -34,4 +34,230 @@ struct SamuiLanguageSchoolTests {
         )
     }
 
+    @MainActor
+    @Test func practiceEvaluatorMatchesExactAnswerWithNormalization() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "  the. ",
+            for: Self.taskItem(id: "item-1"),
+            answerKey: Self.answerKey(entries: [
+                Self.answerEntry(itemId: "item-1", answer: .string("The"))
+            ])
+        )
+
+        #expect(evaluation.state == .correct)
+    }
+
+    @MainActor
+    @Test func practiceEvaluatorAcceptsZeroArticleSynonyms() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "no article",
+            for: Self.taskItem(id: "item-1"),
+            answerKey: Self.answerKey(entries: [
+                Self.answerEntry(itemId: "item-1", answer: .string("zero article"))
+            ])
+        )
+
+        #expect(evaluation.state == .correct)
+    }
+
+    @MainActor
+    @Test func practiceEvaluatorUsesAcceptedAnswers() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "an answer",
+            for: Self.taskItem(id: "item-1"),
+            answerKey: Self.answerKey(entries: [
+                Self.answerEntry(
+                    itemId: "item-1",
+                    answer: nil,
+                    acceptedAnswers: ["a response", "an answer"]
+                )
+            ])
+        )
+
+        #expect(evaluation.state == .correct)
+    }
+
+    @MainActor
+    @Test func practiceEvaluatorExtractsObjectCorrection() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "the Netherlands",
+            for: Self.taskItem(id: "item-1", type: .errorCorrection),
+            answerKey: Self.answerKey(entries: [
+                Self.answerEntry(
+                    itemId: "item-1",
+                    answer: .object([
+                        "error": .string("Netherlands"),
+                        "correction": .string("the Netherlands")
+                    ])
+                )
+            ])
+        )
+
+        #expect(evaluation.state == .correct)
+        #expect(evaluation.expectedAnswer == "Error: Netherlands\nCorrection: the Netherlands")
+    }
+
+    @MainActor
+    @Test func practiceEvaluatorMatchesSortingCategoryByAnswerArray() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "As long as",
+            for: Self.taskItem(
+                id: "item-2",
+                type: .sorting,
+                number: .integer(2),
+                categories: ["Unless", "As long as"]
+            ),
+            answerKey: Self.answerKey(entries: [
+                Self.answerEntry(itemId: "category-unless", answer: .array([.number(1), .number(3)])),
+                Self.answerEntry(itemId: "category-as-long-as", answer: .array([.number(2), .number(4)]))
+            ])
+        )
+
+        #expect(evaluation.state == .correct)
+        #expect(evaluation.expectedAnswer == "As long as")
+    }
+
+    @MainActor
+    @Test func practiceEvaluatorMarksTeacherAssessedItemReviewed() async throws {
+        let evaluation = PracticeAnswerEvaluator.evaluate(
+            response: "My open response",
+            for: Self.taskItem(id: "item-1", type: .freeResponse),
+            answerKey: Self.answerKey(entries: [], teacherNotes: "Teacher-assessed.")
+        )
+
+        #expect(evaluation.state == .reviewed)
+        #expect(!evaluation.isGradable)
+        #expect(evaluation.notes == "Teacher-assessed.")
+    }
+
+    @MainActor
+    @Test func practiceTaskResolverUsesRequestedTaskWhenValid() async throws {
+        let lesson = Self.lesson(tasks: [
+            Self.practiceTask(id: "first-task"),
+            Self.practiceTask(id: "second-task")
+        ])
+
+        #expect(
+            PracticeTaskResolver.selectedTask(in: lesson, requestedTaskID: "second-task")?.id ==
+            "second-task"
+        )
+    }
+
+    @MainActor
+    @Test func practiceTaskResolverFallsBackToFirstTask() async throws {
+        let lesson = Self.lesson(tasks: [
+            Self.practiceTask(id: "first-task"),
+            Self.practiceTask(id: "second-task")
+        ])
+
+        #expect(
+            PracticeTaskResolver.selectedTask(in: lesson, requestedTaskID: "missing-task")?.id ==
+            "first-task"
+        )
+    }
+
+    private static func taskItem(
+        id: String,
+        type: LessonContentModel.TaskItemType = .gapFill,
+        number: LessonContentNumber? = nil,
+        categories: [String]? = nil
+    ) -> LessonContentModel.TaskItem {
+        LessonContentModel.TaskItem(
+            id: id,
+            type: type,
+            number: number,
+            prompt: "Prompt",
+            context: nil,
+            answerType: nil,
+            options: nil,
+            targetForm: nil,
+            targetForms: nil,
+            categories: categories,
+            text: nil,
+            original: nil,
+            newSubject: nil,
+            checklist: nil
+        )
+    }
+
+    private static func answerKey(
+        taskId: String = "task",
+        entries: [LessonContentModel.AnswerEntry],
+        teacherNotes: String? = nil
+    ) -> LessonContentModel.AnswerKeyTask {
+        LessonContentModel.AnswerKeyTask(
+            taskId: taskId,
+            entries: entries,
+            teacherNotes: teacherNotes
+        )
+    }
+
+    private static func answerEntry(
+        itemId: String,
+        answer: JSONValue?,
+        acceptedAnswers: [String]? = nil
+    ) -> LessonContentModel.AnswerEntry {
+        LessonContentModel.AnswerEntry(
+            itemId: itemId,
+            answer: answer,
+            acceptedAnswers: acceptedAnswers,
+            sampleAnswers: nil,
+            explanation: nil,
+            errorType: nil,
+            notes: nil
+        )
+    }
+
+    private static func lesson(tasks: [LessonContentModel.PracticeTask]) -> LessonContentModel {
+        LessonContentModel(
+            id: "lesson",
+            title: "Lesson",
+            level: LessonContentModel.Level(code: "A1", label: "A1", descriptor: nil),
+            subtitle: "Subtitle",
+            estimatedMinutes: LessonContentModel.EstimatedMinutes(min: 1, max: 2),
+            tags: [],
+            source: LessonContentModel.Source(fileName: "file.pdf", pageCount: 1, extractionMethod: nil),
+            screenSummary: LessonContentModel.ScreenSummary(
+                themeTitle: "Theme",
+                levelLabel: "A1",
+                lessonBadge: "Lesson",
+                shortDescription: "Description",
+                estimatedReadTimeLabel: "1 min",
+                primaryPracticeLabel: nil,
+                progressLabel: nil
+            ),
+            learningPath: [],
+            objectives: [],
+            difficultyGuide: [],
+            review: nil,
+            theorySections: [
+                LessonContentModel.TheorySection(
+                    id: "section",
+                    title: "Section",
+                    order: 1,
+                    contentBlocks: [],
+                    tryItTaskIds: []
+                )
+            ],
+            practiceTasks: tasks,
+            answerKey: [],
+            selfAssessment: nil
+        )
+    }
+
+    private static func practiceTask(id: String) -> LessonContentModel.PracticeTask {
+        LessonContentModel.PracticeTask(
+            id: id,
+            title: "Task",
+            sourceLabel: nil,
+            kind: .tryIt,
+            mode: .practice,
+            difficulty: nil,
+            estimatedMinutes: nil,
+            instructions: "Instructions",
+            stimulus: nil,
+            supportingPrompts: nil,
+            items: []
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Reworked `PracticeView` to load the selected lesson and practice task from `lessons.json`, following the same data-loading pattern used by Theory.
- Added in-memory practice session state for item progression, response capture, answer checking, and completion summary.
- Introduced reusable practice support logic for task resolution and answer evaluation, including normalization, accepted answers, sorting, and teacher-assessed items.
- Added unit coverage for answer evaluation behavior and practice task fallback selection.

## Testing
- Added unit tests for normalization, zero-article synonyms, accepted answers, object-based corrections, sorting evaluation, and teacher-assessed review handling.
- Added tests confirming requested task selection and fallback to the first practice task.
- Verified the app and test targets build successfully with the updated Practice implementation.