### PR TITLE
Render practice answer choices inline from lesson data

### DIFF
--- a/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
@@ -49,6 +49,58 @@ enum PracticeEvaluationState: Equatable {
     case reviewed
 }
 
+enum PracticeAnswerOptionBank {
+    static func options(
+        from lesson: LessonContentModel,
+        itemTypes: [LessonContentModel.TaskItemType]
+    ) -> [String] {
+        let eligibleItemIDs = Set(
+            lesson.practiceTasks
+                .flatMap(\.items)
+                .filter { itemTypes.contains($0.type) }
+                .map(\.id)
+        )
+
+        let entries = lesson.answerKey
+            .flatMap(\.entries)
+            .filter { eligibleItemIDs.contains($0.itemId) }
+
+        return options(from: entries)
+    }
+
+    static func options(from answerKey: LessonContentModel.AnswerKeyTask?) -> [String] {
+        guard let answerKey else {
+            return []
+        }
+
+        return options(from: answerKey.entries)
+    }
+
+    private static func options(from entries: [LessonContentModel.AnswerEntry]) -> [String] {
+        var options: [String] = []
+        var seenOptions = Set<String>()
+
+        for entry in entries {
+            for candidate in PracticeAnswerEvaluator.answerCandidates(from: entry) {
+                let option = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !option.isEmpty else {
+                    continue
+                }
+
+                let normalizedOption = PracticeAnswerEvaluator.normalized(option)
+                guard !seenOptions.contains(normalizedOption) else {
+                    continue
+                }
+
+                options.append(option)
+                seenOptions.insert(normalizedOption)
+            }
+        }
+
+        return options
+    }
+}
+
 enum PracticeAnswerEvaluator {
     static func evaluate(
         response: String,
@@ -199,7 +251,7 @@ enum PracticeAnswerEvaluator {
         )
     }
 
-    private static func answerCandidates(from entry: LessonContentModel.AnswerEntry) -> [String] {
+    static func answerCandidates(from entry: LessonContentModel.AnswerEntry) -> [String] {
         var candidates = entry.acceptedAnswers ?? []
 
         if let answer = entry.answer {
@@ -213,7 +265,7 @@ enum PracticeAnswerEvaluator {
         return candidates
     }
 
-    private static func normalized(_ value: String) -> String {
+    static func normalized(_ value: String) -> String {
         let trimmed = value
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?;:"))

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -90,7 +90,7 @@ struct PracticeView: View {
                 taskIntroCard(task: task)
 
                 if let item = currentItem(in: task) {
-                    itemCard(item: item, task: task, answerKey: answerKey(in: lesson, for: task))
+                    itemCard(item: item, lesson: lesson, task: task, answerKey: answerKey(in: lesson, for: task))
                 }
             }
             .padding(.horizontal, SLSSpacing.lg)
@@ -149,6 +149,7 @@ struct PracticeView: View {
 
     private func itemCard(
         item: LessonContentModel.TaskItem,
+        lesson: LessonContentModel,
         task: LessonContentModel.PracticeTask,
         answerKey: LessonContentModel.AnswerKeyTask?
     ) -> some View {
@@ -184,7 +185,7 @@ struct PracticeView: View {
                 }
 
                 itemHints(item)
-                responseInput(for: item)
+                responseInput(for: item, lesson: lesson)
 
                 if let evaluation = evaluations[item.id] {
                     feedbackCard(evaluation: evaluation)
@@ -226,7 +227,10 @@ struct PracticeView: View {
     }
 
     @ViewBuilder
-    private func responseInput(for item: LessonContentModel.TaskItem) -> some View {
+    private func responseInput(
+        for item: LessonContentModel.TaskItem,
+        lesson: LessonContentModel
+    ) -> some View {
         switch item.type {
         case .multipleChoice, .labeling:
             optionList(options: item.options ?? [], item: item)
@@ -236,7 +240,17 @@ struct PracticeView: View {
             SpeakingCompletionCard(isComplete: evaluations[item.id] != nil)
         case .paragraphWriting, .freeResponse:
             textEditor(for: item, minHeight: 150)
-        case .gapFill, .rewrite, .errorCorrection, .tableCompletion:
+        case .gapFill, .tableCompletion:
+            let options = PracticeAnswerOptionBank.options(
+                from: lesson,
+                itemTypes: [.gapFill, .tableCompletion]
+            )
+            if options.isEmpty {
+                textEditor(for: item, minHeight: 92)
+            } else {
+                optionList(options: options, item: item)
+            }
+        case .rewrite, .errorCorrection:
             textEditor(for: item, minHeight: 92)
         }
     }

--- a/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
+++ b/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
@@ -131,6 +131,94 @@ struct SamuiLanguageSchoolTests {
     }
 
     @MainActor
+    @Test func practiceAnswerOptionBankDedupesNormalizedAnswers() async throws {
+        let options = PracticeAnswerOptionBank.options(from: Self.answerKey(entries: [
+            Self.answerEntry(itemId: "item-1", answer: .string("The")),
+            Self.answerEntry(itemId: "item-2", answer: .string("the"))
+        ]))
+
+        #expect(options == ["The"])
+    }
+
+    @MainActor
+    @Test func practiceAnswerOptionBankIncludesAcceptedAnswers() async throws {
+        let options = PracticeAnswerOptionBank.options(from: Self.answerKey(entries: [
+            Self.answerEntry(
+                itemId: "item-1",
+                answer: nil,
+                acceptedAnswers: ["a response", "an answer"]
+            )
+        ]))
+
+        #expect(options == ["a response", "an answer"])
+    }
+
+    @MainActor
+    @Test func practiceAnswerOptionBankFlattensArrayAnswers() async throws {
+        let options = PracticeAnswerOptionBank.options(from: Self.answerKey(entries: [
+            Self.answerEntry(itemId: "item-1", answer: .array([.string("an"), .string("a")])),
+            Self.answerEntry(itemId: "item-2", answer: .string("zero article"))
+        ]))
+
+        #expect(options == ["an", "a", "zero article"])
+    }
+
+    @MainActor
+    @Test func practiceAnswerOptionBankUsesLessonWideShortAnswerEntries() async throws {
+        let lesson = Self.lesson(
+            tasks: [
+                Self.practiceTask(
+                    id: "first-short-task",
+                    items: [
+                        Self.taskItem(id: "item-1", type: .gapFill),
+                        Self.taskItem(id: "item-2", type: .gapFill)
+                    ]
+                ),
+                Self.practiceTask(
+                    id: "second-short-task",
+                    items: [
+                        Self.taskItem(id: "item-3", type: .tableCompletion)
+                    ]
+                ),
+                Self.practiceTask(
+                    id: "rewrite-task",
+                    items: [
+                        Self.taskItem(id: "item-4", type: .rewrite)
+                    ]
+                )
+            ],
+            answerKey: [
+                Self.answerKey(
+                    taskId: "first-short-task",
+                    entries: [
+                        Self.answerEntry(itemId: "item-1", answer: .string("the")),
+                        Self.answerEntry(itemId: "item-2", answer: .string("a"))
+                    ]
+                ),
+                Self.answerKey(
+                    taskId: "second-short-task",
+                    entries: [
+                        Self.answerEntry(itemId: "item-3", answer: .array([.string("an"), .string("zero article")]))
+                    ]
+                ),
+                Self.answerKey(
+                    taskId: "rewrite-task",
+                    entries: [
+                        Self.answerEntry(itemId: "item-4", answer: .string("Rewrite this full sentence."))
+                    ]
+                )
+            ]
+        )
+
+        let options = PracticeAnswerOptionBank.options(
+            from: lesson,
+            itemTypes: [.gapFill, .tableCompletion]
+        )
+
+        #expect(options == ["the", "a", "an", "zero article"])
+    }
+
+    @MainActor
     @Test func practiceTaskResolverUsesRequestedTaskWhenValid() async throws {
         let lesson = Self.lesson(tasks: [
             Self.practiceTask(id: "first-task"),
@@ -208,7 +296,10 @@ struct SamuiLanguageSchoolTests {
         )
     }
 
-    private static func lesson(tasks: [LessonContentModel.PracticeTask]) -> LessonContentModel {
+    private static func lesson(
+        tasks: [LessonContentModel.PracticeTask],
+        answerKey: [LessonContentModel.AnswerKeyTask] = []
+    ) -> LessonContentModel {
         LessonContentModel(
             id: "lesson",
             title: "Lesson",
@@ -240,12 +331,15 @@ struct SamuiLanguageSchoolTests {
                 )
             ],
             practiceTasks: tasks,
-            answerKey: [],
+            answerKey: answerKey,
             selfAssessment: nil
         )
     }
 
-    private static func practiceTask(id: String) -> LessonContentModel.PracticeTask {
+    private static func practiceTask(
+        id: String,
+        items: [LessonContentModel.TaskItem] = []
+    ) -> LessonContentModel.PracticeTask {
         LessonContentModel.PracticeTask(
             id: id,
             title: "Task",
@@ -257,7 +351,7 @@ struct SamuiLanguageSchoolTests {
             instructions: "Instructions",
             stimulus: nil,
             supportingPrompts: nil,
-            items: []
+            items: items
         )
     }
 }


### PR DESCRIPTION
## Summary
- Build Practice answer choices from `lessons.json` lesson-wide short-answer entries instead of a single task-local option.
- Show `gapFill` and `tableCompletion` choices immediately on the screen using the existing answer-row UI, with no extra tap to open a picker.
- Keep rewrite, error correction, free response, paragraph writing, speaking, and the existing multiple-choice/sorting flows unchanged.
- Add unit coverage for deduping, accepted-answer expansion, array flattening, and lesson-wide short-answer filtering.

## Testing
- Added unit tests for the new answer-option bank behavior.
- Ran `xcodebuild test -scheme SamuiLanguageSchool -project SamuiLanguageSchool.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4'` successfully.