### PR TITLE
Wrap Home screen content in a scroll view and match the Lesson start action bar

### DIFF
--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -15,22 +15,20 @@ struct StartView: View {
             SLSColors.background
                 .ignoresSafeArea()
 
-            VStack(spacing: 0) {
+            ScrollView(showsIndicators: false) {
                 header
 
                 VStack(spacing: SLSSpacing.lg) {
                     currentThemeCard
                     levelCard
                     roleCard
-                    Spacer(minLength: 90)
                 }
                 .padding(.horizontal, SLSSpacing.lg)
                 .padding(.top, SLSSpacing.xl)
+                .padding(.bottom, 124)
             }
 
-            SLSPrimaryButton(title: "Start Learning", action: onStartLearning)
-                .padding(.horizontal, SLSSpacing.lg)
-                .padding(.bottom, 34)
+            SLSBottomActionBar(title: "Start Learning", action: onStartLearning)
         }
     }
 


### PR DESCRIPTION
## Summary
- Wrapped the Home/Start screen content in a `ScrollView` so the lower cards can scroll on shorter displays.
- Replaced the sliced bottom button with `SLSBottomActionBar` to match the Lesson screen behavior and safe-area layout.
- Added bottom content padding so the final card stays clear of the persistent action bar.

Resolves  #10

## Testing
- Not run (not requested)