### PR TITLE
Expose all lessons in the learning flow

### DIFF
--- a/SamuiLanguageSchool/ContentView.swift
+++ b/SamuiLanguageSchool/ContentView.swift
@@ -10,19 +10,26 @@ import SwiftUI
 struct ContentView: View {
     @State private var path: [Route] = []
     @StateObject private var progress = ProgressEnvironment()
+    private let contentProvider = LessonContentProvider()
 
     var body: some View {
         NavigationStack(path: $path) {
-            StartView {
-                path.append(.lesson(progress.currentLessonID))
-            }
+            StartView(
+                onStartLearning: {
+                    path.append(.lesson(progress.currentLessonID))
+                },
+                onSelectLesson: { lesson in
+                    path.append(.lesson(lesson.id))
+                }
+            )
             .navigationDestination(for: Route.self) { route in
                 switch route {
                 case .lesson(let lessonID):
                     LessonView(
                         viewModel: LessonViewModel(lessonID: lessonID),
                         onBack: pop,
-                        onStartOrContinue: navigateToProgressDestination
+                        onStartOrContinue: navigateToStep,
+                        onSelectStep: navigateToSelectedStep
                     )
                 case .theory(let lessonID, let sectionID):
                     TheoryView(
@@ -34,7 +41,12 @@ struct ContentView: View {
                         }
                     )
                 case .practice(let lessonID, let taskID):
-                    PracticeView(lessonID: lessonID, taskID: taskID, onBack: pop)
+                    PracticeView(
+                        lessonID: lessonID,
+                        taskID: taskID,
+                        onBack: pop,
+                        onComplete: navigateAfterPracticeCompletion
+                    )
                 }
             }
         }
@@ -46,12 +58,37 @@ struct ContentView: View {
         path.removeLast()
     }
 
-    private func navigateToProgressDestination(lesson: LessonContentModel, destination: ProgressEnvironment.Destination) {
-        switch destination {
-        case .theory(let sectionID):
-            path.append(.theory(lessonID: lesson.id, sectionID: sectionID))
-        case .practice(let taskID):
-            path.append(.practice(lessonID: lesson.id, taskID: taskID))
+    private func navigateToSelectedStep(_ step: LearningStep) {
+        progress.updateProgress(to: step)
+        navigateToStep(step)
+    }
+
+    private func navigateToStep(_ step: LearningStep) {
+        switch step {
+        case .theory(let lessonID, let sectionID):
+            path.append(.theory(lessonID: lessonID, sectionID: sectionID))
+        case .practice(let lessonID, let taskID):
+            path.append(.practice(lessonID: lessonID, taskID: taskID))
+        }
+    }
+
+    private func navigateAfterPracticeCompletion(lesson: LessonContentModel, task: LessonContentModel.PracticeTask) {
+        do {
+            let lessons = try contentProvider.lessonContents()
+            let completedStep = LearningStep.practice(lessonID: lesson.id, taskID: task.id)
+
+            guard let nextStep = LearningStepResolver.nextStep(after: completedStep, in: lessons) else {
+                path.removeAll()
+                return
+            }
+
+            progress.updateProgress(to: nextStep)
+            if !path.isEmpty {
+                path.removeLast()
+            }
+            navigateToStep(nextStep)
+        } catch {
+            path.removeAll()
         }
     }
 }

--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -12,16 +12,19 @@ struct LessonView: View {
     @StateObject private var viewModel: LessonViewModel
 
     var onBack: () -> Void
-    var onStartOrContinue: (LessonContentModel, ProgressEnvironment.Destination) -> Void
+    var onStartOrContinue: (LearningStep) -> Void
+    var onSelectStep: (LearningStep) -> Void
 
     init(
         viewModel: @autoclosure @escaping () -> LessonViewModel = LessonViewModel(),
         onBack: @escaping () -> Void,
-        onStartOrContinue: @escaping (LessonContentModel, ProgressEnvironment.Destination) -> Void
+        onStartOrContinue: @escaping (LearningStep) -> Void,
+        onSelectStep: @escaping (LearningStep) -> Void
     ) {
         _viewModel = StateObject(wrappedValue: viewModel())
         self.onBack = onBack
         self.onStartOrContinue = onStartOrContinue
+        self.onSelectStep = onSelectStep
     }
 
     var body: some View {
@@ -54,11 +57,11 @@ struct LessonView: View {
 
     private func startOrContinue() {
         guard let lesson = viewModel.lesson,
-              let destination = progress.startOrContinueDestination(for: lesson) else {
+              let step = progress.startOrContinueStep(for: lesson) else {
             return
         }
 
-        onStartOrContinue(lesson, destination)
+        onStartOrContinue(step)
     }
 
     @ViewBuilder
@@ -75,6 +78,11 @@ struct LessonView: View {
             VStack(spacing: 22) {
                 LessonSummaryHero(summary: lesson.screenSummary)
                 LearningPathSection(steps: lesson.learningPath)
+                LessonStepsSection(
+                    lesson: lesson,
+                    steps: LearningStepResolver.steps(for: lesson),
+                    onSelectStep: onSelectStep
+                )
                 ObjectivesSection(objectives: lesson.objectives)
                 DifficultyGuideSection(
                     entries: lesson.difficultyGuide,
@@ -236,6 +244,142 @@ private struct LearningPathRow: View {
     }
 }
 
+private struct LessonStepsSection: View {
+    let lesson: LessonContentModel
+    let steps: [LearningStep]
+    let onSelectStep: (LearningStep) -> Void
+
+    var body: some View {
+        SLSCard(padding: 24) {
+            VStack(alignment: .leading, spacing: 18) {
+                SectionHeader(title: "Lesson Steps", iconName: "list.bullet.rectangle.fill")
+
+                VStack(spacing: 12) {
+                    ForEach(Array(steps.enumerated()), id: \.element) { index, step in
+                        Button {
+                            onSelectStep(step)
+                        } label: {
+                            LessonStepRow(
+                                number: index + 1,
+                                title: title(for: step),
+                                subtitle: subtitle(for: step),
+                                iconName: iconName(for: step)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier(accessibilityIdentifier(for: step))
+                    }
+                }
+            }
+        }
+    }
+
+    private func title(for step: LearningStep) -> String {
+        switch step {
+        case .theory(_, let sectionID):
+            return lesson.theorySections.first { $0.id == sectionID }?.title ?? "Theory"
+        case .practice(_, let taskID):
+            return lesson.practiceTasks.first { $0.id == taskID }?.title ?? "Practice"
+        }
+    }
+
+    private func subtitle(for step: LearningStep) -> String {
+        switch step {
+        case .theory(_, let sectionID):
+            guard let section = lesson.theorySections.first(where: { $0.id == sectionID }) else {
+                return "Theory"
+            }
+
+            return "Theory section \(section.order)"
+        case .practice(_, let taskID):
+            guard let task = lesson.practiceTasks.first(where: { $0.id == taskID }) else {
+                return "Practice task"
+            }
+
+            var parts = [practiceKindTitle(task.kind)]
+            if let difficulty = task.difficulty, !difficulty.isEmpty {
+                parts.append(difficulty)
+            }
+            parts.append("\(task.items.count) items")
+            return parts.joined(separator: " | ")
+        }
+    }
+
+    private func iconName(for step: LearningStep) -> String {
+        switch step {
+        case .theory:
+            return "doc.text.fill"
+        case .practice:
+            return "square.and.pencil"
+        }
+    }
+
+    private func practiceKindTitle(_ kind: LessonContentModel.PracticeTaskKind) -> String {
+        switch kind {
+        case .tryIt:
+            return "Try It"
+        case .activity:
+            return "Activity"
+        case .warmUp:
+            return "Warm Up"
+        }
+    }
+
+    private func accessibilityIdentifier(for step: LearningStep) -> String {
+        switch step {
+        case .theory(let lessonID, let sectionID):
+            return "step-\(lessonID)-theory-\(sectionID)"
+        case .practice(let lessonID, let taskID):
+            return "step-\(lessonID)-practice-\(taskID)"
+        }
+    }
+}
+
+private struct LessonStepRow: View {
+    let number: Int
+    let title: String
+    let subtitle: String
+    let iconName: String
+
+    var body: some View {
+        HStack(alignment: .center, spacing: SLSSpacing.md) {
+            Text("\(number)")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(SLSColors.brand)
+                .clipShape(Circle())
+
+            Image(systemName: iconName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(SLSColors.brand)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(SLSTypography.bodyStrong)
+                    .foregroundStyle(SLSColors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(subtitle)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(SLSColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: SLSSpacing.sm)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(SLSColors.textTertiary)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SLSColors.lessonSurface)
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+    }
+}
+
 private struct ObjectivesSection: View {
     let objectives: [String]
 
@@ -386,6 +530,6 @@ private struct SectionHeader: View {
 }
 
 #Preview {
-    LessonView(onBack: {}, onStartOrContinue: { _, _ in })
+    LessonView(onBack: {}, onStartOrContinue: { _ in }, onSelectStep: { _ in })
         .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Features/Lesson/LessonViewModel.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonViewModel.swift
@@ -18,7 +18,7 @@ final class LessonViewModel: ObservableObject {
 
     init(
         provider: any LessonContentProviding = LessonContentProvider(),
-        lessonID: String? = "articles-discourse-part-2"
+        lessonID: String? = nil
     ) {
         self.provider = provider
         self.lessonID = lessonID

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -14,6 +14,7 @@ struct PracticeView: View {
     private let requestedTaskID: String?
     private let providedLessonID: String?
     var onBack: () -> Void
+    var onComplete: (LessonContentModel, LessonContentModel.PracticeTask) -> Void
 
     @State private var activeTaskID: String?
     @State private var currentItemIndex = 0
@@ -21,11 +22,17 @@ struct PracticeView: View {
     @State private var evaluations: [String: PracticeEvaluation] = [:]
     @State private var isComplete = false
 
-    init(lessonID: String? = nil, taskID: String? = nil, onBack: @escaping () -> Void) {
+    init(
+        lessonID: String? = nil,
+        taskID: String? = nil,
+        onBack: @escaping () -> Void,
+        onComplete: @escaping (LessonContentModel, LessonContentModel.PracticeTask) -> Void = { _, _ in }
+    ) {
         _viewModel = StateObject(wrappedValue: LessonViewModel(lessonID: lessonID))
         self.providedLessonID = lessonID
         self.requestedTaskID = taskID
         self.onBack = onBack
+        self.onComplete = onComplete
     }
 
     var body: some View {
@@ -38,7 +45,7 @@ struct PracticeView: View {
                     practiceHeader(task: task)
 
                     if isComplete {
-                        completionContent(task: task)
+                        completionContent(lesson: lesson, task: task)
                     } else {
                         practiceContent(lesson: lesson, task: task)
                     }
@@ -322,7 +329,10 @@ struct PracticeView: View {
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
     }
 
-    private func completionContent(task: LessonContentModel.PracticeTask) -> some View {
+    private func completionContent(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask
+    ) -> some View {
         VStack(spacing: 22) {
             Spacer(minLength: 40)
 
@@ -341,7 +351,9 @@ struct PracticeView: View {
                         .lineSpacing(5)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    SLSPrimaryButton(title: "Done", action: onBack)
+                    SLSPrimaryButton(title: "Continue") {
+                        onComplete(lesson, task)
+                    }
                 }
             }
             .padding(.horizontal, SLSSpacing.lg)

--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -5,10 +5,25 @@
 //  Created by Codex on 30.04.2026.
 //
 
+import Combine
 import SwiftUI
 
 struct StartView: View {
+    @EnvironmentObject private var progress: ProgressEnvironment
+    @StateObject private var viewModel: StartViewModel
+
     var onStartLearning: () -> Void
+    var onSelectLesson: (LessonContentModel) -> Void
+
+    init(
+        viewModel: @autoclosure @escaping () -> StartViewModel = StartViewModel(),
+        onStartLearning: @escaping () -> Void,
+        onSelectLesson: @escaping (LessonContentModel) -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+        self.onStartLearning = onStartLearning
+        self.onSelectLesson = onSelectLesson
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -18,17 +33,23 @@ struct StartView: View {
             ScrollView(showsIndicators: false) {
                 header
 
-                VStack(spacing: SLSSpacing.lg) {
-                    currentThemeCard
-                    levelCard
-                    roleCard
+                VStack(alignment: .leading, spacing: SLSSpacing.lg) {
+                    if viewModel.lessons.isEmpty {
+                        errorContent
+                    } else {
+                        lessonCatalog
+                    }
                 }
                 .padding(.horizontal, SLSSpacing.lg)
                 .padding(.top, SLSSpacing.xl)
                 .padding(.bottom, 124)
             }
 
-            SLSBottomActionBar(title: "Start Learning", action: onStartLearning)
+            SLSBottomActionBar(
+                title: progress.currentLessonID == nil ? "Start Learning" : "Continue Learning",
+                isEnabled: !viewModel.lessons.isEmpty,
+                action: onStartLearning
+            )
         }
     }
 
@@ -54,9 +75,10 @@ struct StartView: View {
                 .foregroundStyle(.white)
                 .padding(.bottom, 14)
 
-            Text("Continue your learning journey")
+            Text("Choose a lesson or continue your learning journey")
                 .font(SLSTypography.heroSubtitle)
                 .foregroundStyle(.white.opacity(0.92))
+                .lineSpacing(5)
                 .padding(.bottom, 45)
         }
         .padding(.horizontal, SLSSpacing.lg)
@@ -65,80 +87,147 @@ struct StartView: View {
         .ignoresSafeArea(edges: .top)
     }
 
-    private var currentThemeCard: some View {
-        SLSCard {
-            VStack(alignment: .leading, spacing: 26) {
-                HStack(alignment: .firstTextBaseline) {
-                    Text("Current Theme")
-                        .font(SLSTypography.cardTitle)
-                        .foregroundStyle(SLSColors.textPrimary)
-                    Spacer()
-                    SLSPill(title: "Active", foreground: SLSColors.brand, background: SLSColors.brandSoft)
-                }
+    private var lessonCatalog: some View {
+        VStack(alignment: .leading, spacing: SLSSpacing.md) {
+            Text("Lessons")
+                .font(SLSTypography.sectionTitle)
+                .foregroundStyle(SLSColors.textPrimary)
 
-                Text("Past Simple Tense")
+            ForEach(viewModel.lessons) { lesson in
+                LessonCatalogCard(
+                    lesson: lesson,
+                    isCurrent: progress.currentLessonID == lesson.id,
+                    action: { onSelectLesson(lesson) }
+                )
+            }
+        }
+    }
+
+    private var errorContent: some View {
+        SLSCard {
+            VStack(alignment: .leading, spacing: SLSSpacing.md) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(SLSColors.brand)
+
+                Text("Lessons unavailable")
+                    .font(SLSTypography.cardTitle)
+                    .foregroundStyle(SLSColors.textPrimary)
+
+                Text(viewModel.errorMessage ?? "Could not load lessons.")
                     .font(SLSTypography.body)
-                    .foregroundStyle(Color(hex: 0x344054))
-
-                HStack(spacing: SLSSpacing.sm) {
-                    SLSProgressBar(value: 0.65)
-                    Text("65%")
-                        .font(SLSTypography.body)
-                        .foregroundStyle(SLSColors.textSecondary)
-                }
-            }
-        }
-    }
-
-    private var levelCard: some View {
-        SLSCard {
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Your Level")
-                    .font(SLSTypography.caption)
                     .foregroundStyle(SLSColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                HStack(alignment: .firstTextBaseline) {
-                    Text("Intermediate")
-                        .font(.system(size: 28, weight: .regular))
-                        .foregroundStyle(SLSColors.textPrimary)
-                    Spacer()
-                    Text("B1")
-                        .font(.system(size: 22, weight: .regular))
-                        .foregroundStyle(SLSColors.textTertiary)
+                Button("Retry") {
+                    viewModel.load()
                 }
-            }
-        }
-    }
-
-    private var roleCard: some View {
-        SLSCard {
-            VStack(alignment: .leading, spacing: SLSSpacing.lg) {
-                Text("Your Role")
-                    .font(SLSTypography.caption)
-                    .foregroundStyle(SLSColors.textSecondary)
-
-                HStack(spacing: SLSSpacing.md) {
-                    Image(systemName: "graduationcap.fill")
-                        .font(.system(size: 24))
-                        .foregroundStyle(SLSColors.textPrimary)
-                        .frame(width: 48, height: 48)
-                        .background(SLSColors.lavenderSoft)
-                        .clipShape(Circle())
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Student")
-                            .font(SLSTypography.bodyStrong)
-                            .foregroundStyle(SLSColors.textPrimary)
-                        Text("General English Course")
-                            .font(.system(size: 17, weight: .regular))
-                            .foregroundStyle(SLSColors.textSecondary)
-                    }
-                }
+                .font(SLSTypography.bodyStrong)
+                .foregroundStyle(SLSColors.brand)
             }
         }
     }
 }
 
+@MainActor
+final class StartViewModel: ObservableObject {
+    @Published private(set) var lessons: [LessonContentModel] = []
+    @Published private(set) var errorMessage: String?
+
+    private let provider: any LessonContentProviding
+
+    init(provider: any LessonContentProviding = LessonContentProvider()) {
+        self.provider = provider
+        load()
+    }
+
+    func load() {
+        do {
+            lessons = try provider.lessonContents()
+            errorMessage = nil
+        } catch {
+            lessons = []
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct LessonCatalogCard: View {
+    let lesson: LessonContentModel
+    let isCurrent: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            SLSCard {
+                VStack(alignment: .leading, spacing: 18) {
+                    HStack(alignment: .top, spacing: SLSSpacing.sm) {
+                        SLSPill(
+                            title: lesson.level.label,
+                            foreground: isCurrent ? .white : SLSColors.brand,
+                            background: isCurrent ? SLSColors.brand : SLSColors.brandSoft
+                        )
+
+                        Spacer(minLength: SLSSpacing.sm)
+
+                        if isCurrent {
+                            SLSPill(title: "Current")
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(lesson.title)
+                            .font(SLSTypography.cardTitle)
+                            .foregroundStyle(SLSColors.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text(lesson.screenSummary.shortDescription)
+                            .font(SLSTypography.body)
+                            .foregroundStyle(SLSColors.textSecondary)
+                            .lineSpacing(4)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack(spacing: SLSSpacing.sm) {
+                        CatalogMetric(iconName: "clock", text: lesson.screenSummary.estimatedReadTimeLabel)
+
+                        if let progressLabel = lesson.screenSummary.progressLabel {
+                            CatalogMetric(iconName: "checklist", text: progressLabel)
+                        }
+                    }
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(lesson.title)
+        .accessibilityIdentifier("lesson-\(lesson.id)")
+    }
+}
+
+private struct CatalogMetric: View {
+    let iconName: String
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: iconName)
+                .font(.system(size: 14, weight: .semibold))
+
+            Text(text)
+                .font(.system(size: 14, weight: .semibold))
+                .lineLimit(2)
+                .minimumScaleFactor(0.86)
+        }
+        .foregroundStyle(SLSColors.textSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SLSColors.lessonSurface)
+        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
+    }
+}
+
 #Preview {
-    StartView {}
+    StartView(onStartLearning: {}, onSelectLesson: { _ in })
+        .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Models/LearningStepResolver.swift
+++ b/SamuiLanguageSchool/Models/LearningStepResolver.swift
@@ -1,0 +1,69 @@
+//
+//  LearningStepResolver.swift
+//  SamuiLanguageSchool
+//
+//  Created by Codex on 02.05.2026.
+//
+
+import Foundation
+
+enum LearningStep: Hashable {
+    case theory(lessonID: String, sectionID: String)
+    case practice(lessonID: String, taskID: String)
+
+    var lessonID: String {
+        switch self {
+        case .theory(let lessonID, _), .practice(let lessonID, _):
+            return lessonID
+        }
+    }
+}
+
+enum LearningStepResolver {
+    static func steps(for lesson: LessonContentModel) -> [LearningStep] {
+        let practiceTaskIDs = Set(lesson.practiceTasks.map(\.id))
+        var steps: [LearningStep] = []
+        var includedTaskIDs = Set<String>()
+
+        for section in lesson.orderedTheorySections {
+            steps.append(.theory(lessonID: lesson.id, sectionID: section.id))
+
+            for taskID in section.tryItTaskIds where practiceTaskIDs.contains(taskID) {
+                guard !includedTaskIDs.contains(taskID) else {
+                    continue
+                }
+
+                steps.append(.practice(lessonID: lesson.id, taskID: taskID))
+                includedTaskIDs.insert(taskID)
+            }
+        }
+
+        for task in lesson.practiceTasks where !includedTaskIDs.contains(task.id) {
+            steps.append(.practice(lessonID: lesson.id, taskID: task.id))
+        }
+
+        return steps
+    }
+
+    static func steps(for lessons: [LessonContentModel]) -> [LearningStep] {
+        lessons.flatMap(steps(for:))
+    }
+
+    static func firstStep(in lesson: LessonContentModel) -> LearningStep? {
+        steps(for: lesson).first
+    }
+
+    static func nextStep(after currentStep: LearningStep, in lessons: [LessonContentModel]) -> LearningStep? {
+        let allSteps = steps(for: lessons)
+        guard let currentIndex = allSteps.firstIndex(of: currentStep) else {
+            return nil
+        }
+
+        let nextIndex = allSteps.index(after: currentIndex)
+        guard allSteps.indices.contains(nextIndex) else {
+            return nil
+        }
+
+        return allSteps[nextIndex]
+    }
+}

--- a/SamuiLanguageSchool/Models/ProgressEnvironment.swift
+++ b/SamuiLanguageSchool/Models/ProgressEnvironment.swift
@@ -10,17 +10,12 @@ import Foundation
 
 @MainActor
 final class ProgressEnvironment: ObservableObject {
-    enum Destination: Equatable {
-        case theory(sectionID: String)
-        case practice(taskID: String)
-    }
-
     @Published var currentLessonID: String?
     @Published var currentTheorySectionID: String?
     @Published var currentPracticeTaskID: String?
 
     init(
-        currentLessonID: String? = "articles-discourse-part-2",
+        currentLessonID: String? = nil,
         currentTheorySectionID: String? = nil,
         currentPracticeTaskID: String? = nil
     ) {
@@ -33,7 +28,7 @@ final class ProgressEnvironment: ObservableObject {
         hasProgress(in: lesson) ? "Continue" : "Start"
     }
 
-    func startOrContinueDestination(for lesson: LessonContentModel) -> Destination? {
+    func startOrContinueStep(for lesson: LessonContentModel) -> LearningStep? {
         if currentLessonID != lesson.id {
             currentLessonID = lesson.id
             currentTheorySectionID = nil
@@ -41,25 +36,39 @@ final class ProgressEnvironment: ObservableObject {
         }
 
         if let taskID = currentPracticeTaskID {
-            return .practice(taskID: taskID)
+            return .practice(lessonID: lesson.id, taskID: taskID)
         }
 
-        guard let sectionID = currentTheorySectionID ?? lesson.firstTheorySection?.id else {
+        if let sectionID = currentTheorySectionID {
+            return .theory(lessonID: lesson.id, sectionID: sectionID)
+        }
+
+        guard let firstStep = LearningStepResolver.firstStep(in: lesson) else {
             return nil
         }
 
-        currentTheorySectionID = sectionID
-        return .theory(sectionID: sectionID)
+        updateProgress(to: firstStep)
+        return firstStep
     }
 
     func updateTheoryProgress(lessonID: String, sectionID: String) {
         currentLessonID = lessonID
         currentTheorySectionID = sectionID
+        currentPracticeTaskID = nil
     }
 
     func updatePracticeProgress(lessonID: String, taskID: String?) {
         currentLessonID = lessonID
         currentPracticeTaskID = taskID
+    }
+
+    func updateProgress(to step: LearningStep) {
+        switch step {
+        case .theory(let lessonID, let sectionID):
+            updateTheoryProgress(lessonID: lessonID, sectionID: sectionID)
+        case .practice(let lessonID, let taskID):
+            updatePracticeProgress(lessonID: lessonID, taskID: taskID)
+        }
     }
 
     private func hasProgress(in lesson: LessonContentModel) -> Bool {

--- a/SamuiLanguageSchool/Services/LessonContentProvider.swift
+++ b/SamuiLanguageSchool/Services/LessonContentProvider.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol LessonContentProviding {
+    func lessonContents() throws -> [LessonContentModel]
     func lessonContent(id: String?) throws -> LessonContentModel
 }
 
@@ -47,7 +48,7 @@ struct LessonContentProvider: LessonContentProviding {
     }
 
     func lessonContent(id: String? = nil) throws -> LessonContentModel {
-        let lessons = try loadLessons()
+        let lessons = try lessonContents()
 
         if let id {
             guard let lesson = lessons.first(where: { $0.id == id }) else {
@@ -62,12 +63,17 @@ struct LessonContentProvider: LessonContentProviding {
         return lesson
     }
 
-    private func loadLessons() throws -> [LessonContentModel] {
+    func lessonContents() throws -> [LessonContentModel] {
         guard let url = bundle.url(forResource: resourceName, withExtension: resourceExtension) else {
             throw ProviderError.missingResource("\(resourceName).\(resourceExtension)")
         }
 
         let data = try Data(contentsOf: url)
-        return try decoder.decode([LessonContentModel].self, from: data)
+        let lessons = try decoder.decode([LessonContentModel].self, from: data)
+        guard !lessons.isEmpty else {
+            throw ProviderError.emptyLessonList
+        }
+
+        return lessons
     }
 }

--- a/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
+++ b/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
@@ -10,6 +10,70 @@ import Testing
 
 struct SamuiLanguageSchoolTests {
 
+    @MainActor
+    @Test func lessonContentProviderLoadsAllBundledLessons() async throws {
+        let lessons = try LessonContentProvider().lessonContents()
+
+        #expect(lessons.map(\.id) == [
+            "articles-discourse-part-2",
+            "unless-as-long-as",
+            "reflexive-pronouns"
+        ])
+    }
+
+    @MainActor
+    @Test func learningStepResolverIncludesEveryTheoryAndPracticeOnce() async throws {
+        let lessons = try LessonContentProvider().lessonContents()
+
+        for lesson in lessons {
+            let steps = LearningStepResolver.steps(for: lesson)
+            let theorySectionIDs = steps.compactMap { step -> String? in
+                guard case .theory(_, let sectionID) = step else {
+                    return nil
+                }
+                return sectionID
+            }
+            let practiceTaskIDs = steps.compactMap { step -> String? in
+                guard case .practice(_, let taskID) = step else {
+                    return nil
+                }
+                return taskID
+            }
+
+            #expect(theorySectionIDs == lesson.orderedTheorySections.map(\.id))
+            #expect(Set(practiceTaskIDs) == Set(lesson.practiceTasks.map(\.id)))
+            #expect(practiceTaskIDs.count == lesson.practiceTasks.count)
+            #expect(steps.count == lesson.theorySections.count + lesson.practiceTasks.count)
+        }
+    }
+
+    @MainActor
+    @Test func learningStepResolverAdvancesThroughTryItTheoryAndNextLesson() async throws {
+        let lessons = try LessonContentProvider().lessonContents()
+        let articles = try #require(lessons.first { $0.id == "articles-discourse-part-2" })
+
+        #expect(
+            LearningStepResolver.nextStep(
+                after: .theory(lessonID: articles.id, sectionID: "article-tracking-system"),
+                in: lessons
+            ) == .practice(lessonID: articles.id, taskID: "articles-try-it-a")
+        )
+
+        #expect(
+            LearningStepResolver.nextStep(
+                after: .practice(lessonID: articles.id, taskID: "articles-try-it-a"),
+                in: lessons
+            ) == .theory(lessonID: articles.id, sectionID: "abstract-nouns-and-articles")
+        )
+
+        #expect(
+            LearningStepResolver.nextStep(
+                after: .practice(lessonID: articles.id, taskID: "articles-activity-7"),
+                in: lessons
+            ) == .theory(lessonID: "unless-as-long-as", sectionID: "unless")
+        )
+    }
+
     @Test func difficultyGuideTitleListUsesActivityNumbers() async throws {
         let titles = [
             "Activity 2 - Articles across a paragraph",

--- a/SamuiLanguageSchoolUITests/SamuiLanguageSchoolUITests.swift
+++ b/SamuiLanguageSchoolUITests/SamuiLanguageSchoolUITests.swift
@@ -23,14 +23,13 @@ final class SamuiLanguageSchoolUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testCatalogShowsMultipleLessons() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // XCUIAutomation Documentation
-        // https://developer.apple.com/documentation/xcuiautomation
+        XCTAssertTrue(app.staticTexts["Articles in Discourse - Part 2"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Unless and As Long As"].exists)
+        XCTAssertTrue(app.staticTexts["Reflexive Pronouns"].exists)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Replaced the single-lesson/default flow with a full catalog sourced from `lessons.json`.
- Added `LearningStepResolver` to order theory sections, try-it tasks, remaining practice tasks, and cross-lesson progression.
- Updated lesson, theory, and practice navigation so students can jump through every lesson and continue to the next step after completion.

Resolves #17

## Testing
- Added unit coverage for bundled lesson loading, step ordering, and next-step resolution across lessons.
- Added a UI smoke test that verifies the catalog renders multiple lessons.
- Ran the full Xcode test suite successfully after the flow changes.