### PR TITLE
Reduce iPhone typography and spacing across learning screens

### DIFF
--- a/SamuiLanguageSchool/DesignSystem/SLSComponents.swift
+++ b/SamuiLanguageSchool/DesignSystem/SLSComponents.swift
@@ -22,7 +22,7 @@ struct SLSTopBar: View {
                 if let backAction {
                     Button(action: backAction) {
                         Image(systemName: "chevron.left")
-                            .font(.system(size: 22, weight: .semibold))
+                            .font(.system(size: 20, weight: .semibold))
                             .foregroundStyle(SLSColors.brand)
                             .frame(width: 44, height: 44)
                     }
@@ -32,7 +32,7 @@ struct SLSTopBar: View {
                 Spacer()
             }
         }
-        .frame(height: 88)
+        .frame(height: 56)
         .padding(.horizontal, SLSSpacing.lg)
         .background(SLSColors.surface)
         .overlay(alignment: .bottom) {
@@ -68,8 +68,8 @@ struct SLSPill: View {
         Text(title)
             .font(SLSTypography.caption)
             .foregroundStyle(foreground)
-            .padding(.horizontal, SLSSpacing.md)
-            .padding(.vertical, 7)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
             .background(background)
             .clipShape(Capsule())
     }
@@ -111,11 +111,11 @@ struct SLSPrimaryButton: View {
                     .font(SLSTypography.button)
                 Spacer()
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 24, weight: .bold))
+                    .font(.system(size: 20, weight: .bold))
             }
             .foregroundStyle(isEnabled ? .white : SLSColors.textTertiary)
-            .padding(.horizontal, 20)
-            .frame(height: 68)
+            .padding(.horizontal, 16)
+            .frame(height: 56)
             .background(isEnabled ? SLSColors.brand : SLSColors.disabledFill)
             .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
             .shadow(color: isEnabled ? SLSColors.brand.opacity(0.22) : .clear, radius: 12, x: 0, y: 6)
@@ -137,8 +137,8 @@ struct SLSBottomActionBar: View {
                 .frame(height: 1)
             SLSPrimaryButton(title: title, isEnabled: isEnabled, action: action)
                 .padding(.horizontal, SLSSpacing.lg)
-                .padding(.top, SLSSpacing.lg)
-                .padding(.bottom, 32)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
                 .background(SLSColors.surface)
         }
     }
@@ -149,9 +149,9 @@ struct SLSIconCircle: View {
 
     var body: some View {
         Image(systemName: systemName)
-            .font(.system(size: 23, weight: .semibold))
+            .font(.system(size: 20, weight: .semibold))
             .foregroundStyle(.white)
-            .frame(width: 46, height: 46)
+            .frame(width: 44, height: 44)
             .background(.white.opacity(0.24))
             .clipShape(Circle())
     }

--- a/SamuiLanguageSchool/DesignSystem/SLSSpacing.swift
+++ b/SamuiLanguageSchool/DesignSystem/SLSSpacing.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 enum SLSSpacing {
-    static let xs: CGFloat = 8
-    static let sm: CGFloat = 12
-    static let md: CGFloat = 16
-    static let lg: CGFloat = 24
-    static let xl: CGFloat = 32
+    static let xs: CGFloat = 6
+    static let sm: CGFloat = 10
+    static let md: CGFloat = 14
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 24
 }
 
 enum SLSRadius {
-    static let sm: CGFloat = 12
-    static let md: CGFloat = 18
-    static let lg: CGFloat = 24
-    static let xl: CGFloat = 28
+    static let sm: CGFloat = 10
+    static let md: CGFloat = 14
+    static let lg: CGFloat = 18
+    static let xl: CGFloat = 20
 }

--- a/SamuiLanguageSchool/DesignSystem/SLSTypography.swift
+++ b/SamuiLanguageSchool/DesignSystem/SLSTypography.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 enum SLSTypography {
-    static let navigationTitle = Font.system(size: 20, weight: .bold)
-    static let heroTitle = Font.system(size: 34, weight: .bold)
-    static let heroSubtitle = Font.system(size: 20, weight: .regular)
-    static let cardTitle = Font.system(size: 25, weight: .bold)
-    static let sectionTitle = Font.system(size: 22, weight: .bold)
-    static let body = Font.system(size: 19, weight: .regular)
-    static let bodyStrong = Font.system(size: 19, weight: .semibold)
-    static let caption = Font.system(size: 16, weight: .semibold)
-    static let button = Font.system(size: 22, weight: .bold)
-    static let question = Font.system(size: 30, weight: .bold)
+    static let navigationTitle = Font.system(size: 17, weight: .semibold)
+    static let heroTitle = Font.system(size: 28, weight: .bold)
+    static let heroSubtitle = Font.system(size: 16, weight: .regular)
+    static let cardTitle = Font.system(size: 20, weight: .bold)
+    static let sectionTitle = Font.system(size: 18, weight: .bold)
+    static let body = Font.system(size: 16, weight: .regular)
+    static let bodyStrong = Font.system(size: 16, weight: .semibold)
+    static let caption = Font.system(size: 13, weight: .semibold)
+    static let button = Font.system(size: 17, weight: .semibold)
+    static let question = Font.system(size: 22, weight: .bold)
 }

--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -75,7 +75,7 @@ struct LessonView: View {
 
     private func lessonContent(_ lesson: LessonContentModel) -> some View {
         ScrollView(showsIndicators: false) {
-            VStack(spacing: 22) {
+            VStack(spacing: 18) {
                 LessonSummaryHero(summary: lesson.screenSummary)
                 LearningPathSection(steps: lesson.learningPath)
                 LessonStepsSection(
@@ -90,15 +90,15 @@ struct LessonView: View {
                 )
             }
             .padding(.horizontal, SLSSpacing.lg)
-            .padding(.top, 24)
-            .padding(.bottom, 124)
+            .padding(.top, SLSSpacing.lg)
+            .padding(.bottom, 104)
         }
     }
 
     private var errorContent: some View {
         VStack(spacing: SLSSpacing.lg) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 38, weight: .semibold))
+                .font(.system(size: 32, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
 
             Text("Lesson unavailable")
@@ -125,7 +125,7 @@ private struct LessonSummaryHero: View {
     let summary: LessonContentModel.ScreenSummary
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 28) {
+        VStack(alignment: .leading, spacing: 20) {
             HStack(alignment: .top) {
                 SLSPill(
                     title: summary.lessonBadge,
@@ -136,22 +136,22 @@ private struct LessonSummaryHero: View {
                 Text(summary.levelLabel)
                     .font(SLSTypography.caption)
                     .foregroundStyle(.white)
-                    .padding(.horizontal, 13)
-                    .padding(.vertical, 7)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
                     .background(.white.opacity(0.18))
                     .clipShape(Capsule())
             }
 
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 10) {
                 Text(summary.themeTitle)
-                    .font(.system(size: 32, weight: .bold))
+                    .font(.system(size: 26, weight: .bold))
                     .foregroundStyle(.white)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(summary.shortDescription)
                     .font(SLSTypography.heroSubtitle)
                     .foregroundStyle(.white.opacity(0.92))
-                    .lineSpacing(5)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -162,7 +162,7 @@ private struct LessonSummaryHero: View {
                 }
             }
         }
-        .padding(26)
+        .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             LinearGradient(
@@ -189,8 +189,8 @@ private struct SummaryMetric: View {
                 .minimumScaleFactor(0.86)
         }
         .foregroundStyle(.white)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.white.opacity(0.18))
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
@@ -201,11 +201,11 @@ private struct LearningPathSection: View {
     let steps: [LessonContentModel.LearningPathStep]
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 22) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 18) {
                 SectionHeader(title: "Learning Path", iconName: "map.fill")
 
-                VStack(spacing: 18) {
+                VStack(spacing: 14) {
                     ForEach(Array(steps.enumerated()), id: \.element.id) { index, step in
                         LearningPathRow(stepNumber: index + 1, step: step)
                     }
@@ -222,9 +222,9 @@ private struct LearningPathRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: SLSSpacing.md) {
             Text("\(stepNumber)")
-                .font(.system(size: 17, weight: .bold))
+                .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(.white)
-                .frame(width: 34, height: 34)
+                .frame(width: 30, height: 30)
                 .background(SLSColors.brand)
                 .clipShape(Circle())
 
@@ -234,9 +234,9 @@ private struct LearningPathRow: View {
                     .foregroundStyle(SLSColors.textPrimary)
 
                 Text(step.instructions)
-                    .font(.system(size: 17, weight: .regular))
+                    .font(SLSTypography.body)
                     .foregroundStyle(SLSColors.textSecondary)
-                    .lineSpacing(4)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -250,8 +250,8 @@ private struct LessonStepsSection: View {
     let onSelectStep: (LearningStep) -> Void
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 18) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 16) {
                 SectionHeader(title: "Lesson Steps", iconName: "list.bullet.rectangle.fill")
 
                 VStack(spacing: 12) {
@@ -342,18 +342,18 @@ private struct LessonStepRow: View {
     let iconName: String
 
     var body: some View {
-        HStack(alignment: .center, spacing: SLSSpacing.md) {
+        HStack(alignment: .center, spacing: SLSSpacing.sm) {
             Text("\(number)")
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(.white)
-                .frame(width: 34, height: 34)
+                .frame(width: 30, height: 30)
                 .background(SLSColors.brand)
                 .clipShape(Circle())
 
             Image(systemName: iconName)
-                .font(.system(size: 18, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
-                .frame(width: 32)
+                .frame(width: 26)
 
             VStack(alignment: .leading, spacing: 5) {
                 Text(title)
@@ -373,7 +373,7 @@ private struct LessonStepRow: View {
                 .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(SLSColors.textTertiary)
         }
-        .padding(14)
+        .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SLSColors.lessonSurface)
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -384,11 +384,11 @@ private struct ObjectivesSection: View {
     let objectives: [String]
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 18) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 16) {
                 SectionHeader(title: "Objectives", iconName: "target")
 
-                VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 12) {
                     ForEach(Array(objectives.enumerated()), id: \.offset) { _, objective in
                         ObjectiveRow(text: objective)
                     }
@@ -404,12 +404,12 @@ private struct ObjectiveRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: SLSSpacing.sm) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 19, weight: .semibold))
+                .font(.system(size: 17, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
                 .padding(.top, 2)
 
             Text(text)
-                .font(.system(size: 17, weight: .regular))
+                .font(SLSTypography.body)
                 .foregroundStyle(SLSColors.textPrimary)
                 .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
@@ -426,11 +426,11 @@ private struct DifficultyGuideSection: View {
     }
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 18) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 16) {
                 SectionHeader(title: "Difficulty Guide", iconName: "chart.bar.fill")
 
-                VStack(spacing: 14) {
+                VStack(spacing: 12) {
                     ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
                         DifficultyGuideRow(
                             entry: entry,
@@ -450,9 +450,9 @@ private struct DifficultyGuideRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: SLSSpacing.md) {
             Text(entry.rating)
-                .font(.system(size: 18, weight: .bold))
+                .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(SLSColors.brand)
-                .frame(width: 42, height: 42)
+                .frame(width: 36, height: 36)
                 .background(SLSColors.brandSoft)
                 .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))
 
@@ -471,7 +471,7 @@ private struct DifficultyGuideRow: View {
 
             Spacer(minLength: 0)
         }
-        .padding(16)
+        .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SLSColors.lessonSurface)
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -516,9 +516,9 @@ private struct SectionHeader: View {
     var body: some View {
         HStack(spacing: SLSSpacing.sm) {
             Image(systemName: iconName)
-                .font(.system(size: 18, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
-                .frame(width: 34, height: 34)
+                .frame(width: 30, height: 30)
                 .background(SLSColors.brandSoft)
                 .clipShape(Circle())
 

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -73,12 +73,12 @@ struct PracticeView: View {
             HStack(spacing: SLSSpacing.md) {
                 SLSProgressBar(value: progressValue(for: task))
                 Text(progressText(for: task))
-                    .font(.system(size: 19, weight: .regular))
+                    .font(.system(size: 15, weight: .regular))
                     .foregroundStyle(SLSColors.textSecondary)
             }
             .padding(.horizontal, SLSSpacing.lg)
             .padding(.top, 4)
-            .padding(.bottom, 26)
+            .padding(.bottom, 14)
         }
         .background(SLSColors.surface)
         .overlay(alignment: .bottom) {
@@ -93,11 +93,11 @@ struct PracticeView: View {
         task: LessonContentModel.PracticeTask
     ) -> some View {
         let bottomPadding: CGFloat = currentItem(in: task).map {
-            bottomActionState(lesson: lesson, task: task, item: $0) == nil ? 24 : 130
-        } ?? 24
+            bottomActionState(lesson: lesson, task: task, item: $0) == nil ? 20 : 108
+        } ?? 20
 
         return ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: 18) {
                 taskIntroCard(task: task)
 
                 if let item = currentItem(in: task) {
@@ -105,14 +105,14 @@ struct PracticeView: View {
                 }
             }
             .padding(.horizontal, SLSSpacing.lg)
-            .padding(.top, 24)
+            .padding(.top, SLSSpacing.lg)
             .padding(.bottom, bottomPadding)
         }
     }
 
     private func taskIntroCard(task: LessonContentModel.PracticeTask) -> some View {
         SLSCard {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 14) {
                 HStack(alignment: .top, spacing: SLSSpacing.sm) {
                     SLSPill(title: task.sourceLabel ?? task.kind.title)
 
@@ -140,8 +140,8 @@ struct PracticeView: View {
                     Text(stimulus)
                         .font(SLSTypography.body)
                         .foregroundStyle(SLSColors.textPrimary)
-                        .lineSpacing(5)
-                        .padding(16)
+                        .lineSpacing(4)
+                        .padding(14)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(SLSColors.lessonSurface)
                         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -165,7 +165,7 @@ struct PracticeView: View {
         answerKey: LessonContentModel.AnswerKeyTask?
     ) -> some View {
         SLSCard {
-            VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: 18) {
                 HStack(alignment: .top) {
                     SLSPill(title: itemLabel(for: item, index: currentItemIndex))
                     Spacer(minLength: SLSSpacing.sm)
@@ -182,9 +182,9 @@ struct PracticeView: View {
                 }
 
                 Text(item.prompt)
-                    .font(.system(size: 25, weight: .bold))
+                    .font(SLSTypography.question)
                     .foregroundStyle(SLSColors.textPrimary)
-                    .lineSpacing(7)
+                    .lineSpacing(5)
                     .fixedSize(horizontal: false, vertical: true)
 
                 if let original = item.original {
@@ -387,7 +387,7 @@ struct PracticeView: View {
             .font(SLSTypography.body)
             .foregroundStyle(SLSColors.textPrimary)
             .frame(minHeight: minHeight)
-            .padding(12)
+            .padding(10)
             .scrollContentBackground(.hidden)
             .background(SLSColors.background)
             .overlay {
@@ -402,7 +402,7 @@ struct PracticeView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 10) {
                 Image(systemName: feedbackIcon(for: evaluation))
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(.system(size: 18, weight: .semibold))
 
                 Text(feedbackTitle(for: evaluation))
                     .font(SLSTypography.bodyStrong)
@@ -429,7 +429,7 @@ struct PracticeView: View {
                 PracticeDetailBlock(title: "Notes", text: notes)
             }
         }
-        .padding(16)
+        .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(feedbackColor(for: evaluation).opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -439,8 +439,8 @@ struct PracticeView: View {
         lesson: LessonContentModel,
         task: LessonContentModel.PracticeTask
     ) -> some View {
-        VStack(spacing: 22) {
-            Spacer(minLength: 40)
+        VStack(spacing: 18) {
+            Spacer(minLength: 28)
 
             SLSCard {
                 VStack(alignment: .leading, spacing: 20) {
@@ -472,7 +472,7 @@ struct PracticeView: View {
     private var errorContent: some View {
         VStack(spacing: SLSSpacing.lg) {
             Image(systemName: "questionmark.app.dashed")
-                .font(.system(size: 38, weight: .semibold))
+                .font(.system(size: 32, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
 
             Text("Practice unavailable")
@@ -816,13 +816,13 @@ private struct AnswerOptionButton: View {
                 Spacer()
                 if let iconName = state.iconName {
                     Image(systemName: iconName)
-                        .font(.system(size: 22, weight: .semibold))
+                        .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(state.iconColor)
                 }
             }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 18)
-            .frame(maxWidth: .infinity, minHeight: 66, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
             .background(state.backgroundColor)
             .overlay {
                 RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous)
@@ -877,14 +877,14 @@ private struct SpeakingCompletionCard: View {
     var body: some View {
         HStack(spacing: SLSSpacing.md) {
             Image(systemName: isComplete ? "checkmark.circle.fill" : "mic.circle.fill")
-                .font(.system(size: 28, weight: .semibold))
+                .font(.system(size: 24, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
 
             Text(isComplete ? "Completed" : "Ready for speaking practice")
                 .font(SLSTypography.bodyStrong)
                 .foregroundStyle(SLSColors.textPrimary)
         }
-        .padding(18)
+        .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SLSColors.lessonSurface)
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))

--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -41,8 +41,8 @@ struct StartView: View {
                     }
                 }
                 .padding(.horizontal, SLSSpacing.lg)
-                .padding(.top, SLSSpacing.xl)
-                .padding(.bottom, 124)
+                .padding(.top, SLSSpacing.lg)
+                .padding(.bottom, 104)
             }
 
             SLSBottomActionBar(
@@ -66,20 +66,20 @@ struct StartView: View {
                             .stroke(.white.opacity(0.22), lineWidth: 6)
                     }
             }
-            .padding(.top, 24)
+            .padding(.top, 16)
 
             Spacer()
 
             Text("Welcome back!")
                 .font(SLSTypography.heroTitle)
                 .foregroundStyle(.white)
-                .padding(.bottom, 12)
+                .padding(.bottom, 8)
 
             Text("Choose a lesson or continue your learning journey")
                 .font(SLSTypography.heroSubtitle)
                 .foregroundStyle(.white.opacity(0.92))
-                .lineSpacing(5)
-                .padding(.bottom, 20)
+                .lineSpacing(3)
+                .padding(.bottom, 16)
         }
         .padding(.horizontal, SLSSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -160,7 +160,7 @@ private struct LessonCatalogCard: View {
     var body: some View {
         Button(action: action) {
             SLSCard {
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 14) {
                     HStack(alignment: .top, spacing: SLSSpacing.sm) {
                         SLSPill(
                             title: lesson.level.label,
@@ -175,7 +175,7 @@ private struct LessonCatalogCard: View {
                         }
                     }
 
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 8) {
                         Text(lesson.title)
                             .font(SLSTypography.cardTitle)
                             .foregroundStyle(SLSColors.textPrimary)
@@ -184,7 +184,7 @@ private struct LessonCatalogCard: View {
                         Text(lesson.screenSummary.shortDescription)
                             .font(SLSTypography.body)
                             .foregroundStyle(SLSColors.textSecondary)
-                            .lineSpacing(4)
+                            .lineSpacing(3)
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
@@ -219,8 +219,8 @@ private struct CatalogMetric: View {
                 .minimumScaleFactor(0.86)
         }
         .foregroundStyle(SLSColors.textSecondary)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SLSColors.lessonSurface)
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))

--- a/SamuiLanguageSchool/Features/Theory/TheoryView.swift
+++ b/SamuiLanguageSchool/Features/Theory/TheoryView.swift
@@ -61,7 +61,7 @@ struct TheoryView: View {
 
     private func theoryContent(lesson: LessonContentModel, section: LessonContentModel.TheorySection) -> some View {
         ScrollView(showsIndicators: false) {
-            VStack(spacing: 22) {
+            VStack(spacing: 18) {
                 TheoryHeroCard(summary: lesson.screenSummary, section: section, lessonTitle: lesson.title)
 
                 ForEach(Array(section.contentBlocks.enumerated()), id: \.offset) { _, block in
@@ -69,15 +69,15 @@ struct TheoryView: View {
                 }
             }
             .padding(.horizontal, SLSSpacing.lg)
-            .padding(.top, 24)
-            .padding(.bottom, 130)
+            .padding(.top, SLSSpacing.lg)
+            .padding(.bottom, 108)
         }
     }
 
     private var errorContent: some View {
         VStack(spacing: SLSSpacing.lg) {
             Image(systemName: "doc.text.magnifyingglass")
-                .font(.system(size: 38, weight: .semibold))
+                .font(.system(size: 32, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
 
             Text("Theory unavailable")
@@ -130,7 +130,7 @@ private struct TheoryHeroCard: View {
     let lessonTitle: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 28) {
+        VStack(alignment: .leading, spacing: 20) {
             HStack(alignment: .top) {
                 SLSPill(
                     title: "Section \(section.order)",
@@ -143,26 +143,26 @@ private struct TheoryHeroCard: View {
                 Text(summary.estimatedReadTimeLabel)
                     .font(SLSTypography.caption)
                     .foregroundStyle(.white)
-                    .padding(.horizontal, 13)
-                    .padding(.vertical, 7)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
                     .background(.white.opacity(0.18))
                     .clipShape(Capsule())
             }
 
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 10) {
                 Text(section.title)
-                    .font(.system(size: 31, weight: .bold))
+                    .font(.system(size: 25, weight: .bold))
                     .foregroundStyle(.white)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(lessonTitle)
                     .font(SLSTypography.heroSubtitle)
                     .foregroundStyle(.white.opacity(0.92))
-                    .lineSpacing(5)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(26)
+        .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             LinearGradient(
@@ -202,7 +202,7 @@ private struct TextBlockView: View {
     let block: LessonContentModel.ContentBlock
 
     var body: some View {
-        SLSCard(padding: 24) {
+        SLSCard(padding: 18) {
             VStack(alignment: .leading, spacing: 12) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
@@ -211,7 +211,7 @@ private struct TextBlockView: View {
                 Text(block.text ?? "")
                     .font(SLSTypography.body)
                     .foregroundStyle(SLSColors.textPrimary)
-                    .lineSpacing(5)
+                    .lineSpacing(4)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -222,18 +222,18 @@ private struct FormulaBlockView: View {
     let block: LessonContentModel.ContentBlock
 
     var body: some View {
-        SLSCard(padding: 24) {
+        SLSCard(padding: 18) {
             VStack(alignment: .leading, spacing: 14) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
                 }
 
                 Text(block.formula ?? "")
-                    .font(.system(size: 24, weight: .bold))
+                    .font(.system(size: 20, weight: .bold))
                     .foregroundStyle(SLSColors.brandStrong)
-                    .lineSpacing(6)
+                    .lineSpacing(4)
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(18)
+                    .padding(14)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(SLSColors.lessonSurface)
                     .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -250,13 +250,13 @@ private struct ListBlockView: View {
     }
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 16) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 14) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
                 }
 
-                VStack(alignment: .leading, spacing: 13) {
+                VStack(alignment: .leading, spacing: 11) {
                     ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                         TheoryBulletRow(text: item)
                     }
@@ -274,8 +274,8 @@ private struct ExampleBlockView: View {
     }
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 16) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 14) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
                 }
@@ -284,12 +284,12 @@ private struct ExampleBlockView: View {
                     Text(text)
                         .font(SLSTypography.body)
                         .foregroundStyle(SLSColors.textPrimary)
-                        .lineSpacing(5)
+                        .lineSpacing(4)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if !examples.isEmpty {
-                    VStack(alignment: .leading, spacing: 13) {
+                    VStack(alignment: .leading, spacing: 11) {
                         ForEach(Array(examples.enumerated()), id: \.offset) { _, example in
                             TheoryBulletRow(text: example)
                         }
@@ -312,8 +312,8 @@ private struct TableBlockView: View {
     }
 
     var body: some View {
-        SLSCard(padding: 24) {
-            VStack(alignment: .leading, spacing: 16) {
+        SLSCard(padding: 18) {
+            VStack(alignment: .leading, spacing: 14) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
                 }
@@ -353,7 +353,7 @@ private struct CalloutBlockView: View {
     let block: LessonContentModel.ContentBlock
 
     var body: some View {
-        SLSCard(padding: 24) {
+        SLSCard(padding: 18) {
             VStack(alignment: .leading, spacing: 15) {
                 HStack(spacing: SLSSpacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -375,12 +375,12 @@ private struct CalloutBlockView: View {
                     Text(explanation)
                         .font(SLSTypography.body)
                         .foregroundStyle(SLSColors.textPrimary)
-                        .lineSpacing(5)
+                        .lineSpacing(4)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if let items = block.items {
-                    VStack(alignment: .leading, spacing: 13) {
+                    VStack(alignment: .leading, spacing: 11) {
                         ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                             TheoryBulletRow(text: item)
                         }
@@ -395,7 +395,7 @@ private struct ModelTextBlockView: View {
     let block: LessonContentModel.ContentBlock
 
     var body: some View {
-        SLSCard(padding: 24) {
+        SLSCard(padding: 18) {
             VStack(alignment: .leading, spacing: 14) {
                 if let title = block.title {
                     TheoryBlockTitle(title)
@@ -404,9 +404,9 @@ private struct ModelTextBlockView: View {
                 Text(block.text ?? "")
                     .font(SLSTypography.body)
                     .foregroundStyle(SLSColors.textPrimary)
-                    .lineSpacing(6)
+                    .lineSpacing(4)
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(18)
+                    .padding(14)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(SLSColors.lessonSurface)
                     .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
@@ -436,7 +436,7 @@ private struct TheoryBulletRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: SLSSpacing.sm) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 17, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(SLSColors.brand)
                 .padding(.top, 3)
 
@@ -455,13 +455,13 @@ private struct TableCell: View {
 
     var body: some View {
         Text(text)
-            .font(isHeader ? SLSTypography.bodyStrong : .system(size: 15, weight: .regular))
+            .font(isHeader ? SLSTypography.bodyStrong : .system(size: 14, weight: .regular))
             .foregroundStyle(isHeader ? .white : SLSColors.textPrimary)
             .lineSpacing(4)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(12)
-            .frame(width: 190, alignment: .topLeading)
-            .frame(minHeight: 54, alignment: .topLeading)
+            .padding(10)
+            .frame(width: 170, alignment: .topLeading)
+            .frame(minHeight: 48, alignment: .topLeading)
             .background(isHeader ? SLSColors.brand : Color.clear)
             .overlay(alignment: .trailing) {
                 Rectangle()
@@ -490,10 +490,10 @@ private struct LabeledCalloutText: View {
             Text(text)
                 .font(SLSTypography.body)
                 .foregroundStyle(SLSColors.textPrimary)
-                .lineSpacing(5)
+                .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(14)
+        .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(color.opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: SLSRadius.sm, style: .continuous))


### PR DESCRIPTION
## Summary
- Lowered the shared type scale so the app reads more like dense learning content and less like oversized display text on iPhone.
- Reduced horizontal/vertical spacing, card padding, and radius values to better match iOS density guidelines.
- Tightened the Start, Lesson, Theory, and Practice screens so more content fits above the fold.

Resolves #23

## Testing
- `xcodebuild -scheme SamuiLanguageSchool -project SamuiLanguageSchool.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17' build` passed.
- Verified the changes compile after the typography and spacing adjustments.