### PR TITLE
Reset practice state when advancing to the next queued task

### DIFF
--- a/SamuiLanguageSchool/ContentView.swift
+++ b/SamuiLanguageSchool/ContentView.swift
@@ -47,6 +47,7 @@ struct ContentView: View {
                         onBack: pop,
                         onComplete: navigateAfterPracticeCompletion
                     )
+                    .id(Route.practice(lessonID: lessonID, taskID: taskID))
                 }
             }
         }

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -64,6 +64,9 @@ struct PracticeView: View {
         }
         .navigationBarBackButtonHidden()
         .onAppear(perform: syncProgress)
+        .onChange(of: selectedTaskID) { _, _ in
+            syncProgress()
+        }
     }
 
     private func practiceHeader(task: LessonContentModel.PracticeTask) -> some View {
@@ -575,6 +578,14 @@ struct PracticeView: View {
 
     private func selectedTask(in lesson: LessonContentModel) -> LessonContentModel.PracticeTask? {
         PracticeTaskResolver.selectedTask(in: lesson, requestedTaskID: requestedTaskID)
+    }
+
+    private var selectedTaskID: String? {
+        guard let lesson = viewModel.lesson else {
+            return nil
+        }
+
+        return selectedTask(in: lesson)?.id
     }
 
     private func answerKey(


### PR DESCRIPTION
## Summary
- Reset the practice session when the selected task changes so queued practices start in a fresh question-answer state.
- Give practice routes a stable identity in `ContentView` to prevent SwiftUI from reusing stale view state across different tasks.

Resolve #26

## Testing
- Ran the app test suite locally with `xcodebuild test` on the iPhone 17 simulator.
- Verified the unit and UI test suites passed after the practice navigation change.