### PR TITLE
Add fast short repeat mode with theory fallback

### DIFF
--- a/SamuiLanguageSchool/ContentView.swift
+++ b/SamuiLanguageSchool/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
                 onStartLearning: {
                     path.append(.lesson(progress.currentLessonID))
                 },
+                onStartShortRepeat: startShortRepeat,
                 onSelectLesson: { lesson in
                     path.append(.lesson(lesson.id))
                 }
@@ -48,6 +49,15 @@ struct ContentView: View {
                         onComplete: navigateAfterPracticeCompletion
                     )
                     .id(Route.practice(lessonID: lessonID, taskID: taskID))
+                case .shortRepeat(let selection):
+                    PracticeView(
+                        lessonID: selection.lessonID,
+                        taskID: selection.taskID,
+                        mode: .shortRepeat(itemID: selection.itemID),
+                        onBack: pop,
+                        onComplete: navigateAfterShortRepeatCompletion
+                    )
+                    .id(Route.shortRepeat(selection))
                 }
             }
         }
@@ -73,7 +83,24 @@ struct ContentView: View {
         }
     }
 
-    private func navigateAfterPracticeCompletion(lesson: LessonContentModel, task: LessonContentModel.PracticeTask) {
+    private func startShortRepeat() {
+        do {
+            let lessons = try contentProvider.lessonContents()
+            guard let selection = ShortRepeatPracticeSelector.randomSelection(in: lessons) else {
+                return
+            }
+
+            path.append(.shortRepeat(selection))
+        } catch {
+            path.removeAll()
+        }
+    }
+
+    private func navigateAfterPracticeCompletion(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask,
+        result: PracticeSessionResult
+    ) {
         do {
             let lessons = try contentProvider.lessonContents()
             let completedStep = LearningStep.practice(lessonID: lesson.id, taskID: task.id)
@@ -92,12 +119,31 @@ struct ContentView: View {
             path.removeAll()
         }
     }
+
+    private func navigateAfterShortRepeatCompletion(
+        lesson: LessonContentModel,
+        task: LessonContentModel.PracticeTask,
+        result: PracticeSessionResult
+    ) {
+        if !path.isEmpty {
+            path.removeLast()
+        }
+
+        guard result.hasErrors,
+              let section = LearningStepResolver.relevantTheorySection(forPracticeTaskID: task.id, in: lesson) else {
+            path.removeAll()
+            return
+        }
+
+        path.append(.theory(lessonID: lesson.id, sectionID: section.id))
+    }
 }
 
 private enum Route: Hashable {
     case lesson(String?)
     case theory(lessonID: String, sectionID: String)
     case practice(lessonID: String, taskID: String?)
+    case shortRepeat(ShortRepeatPracticeSelection)
 }
 
 #Preview {

--- a/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeSessionSupport.swift
@@ -7,6 +7,73 @@
 
 import Foundation
 
+struct ShortRepeatPracticeSelection: Hashable {
+    let lessonID: String
+    let taskID: String
+    let itemID: String
+}
+
+enum ShortRepeatPracticeSelector {
+    static func randomSelection(in lessons: [LessonContentModel]) -> ShortRepeatPracticeSelection? {
+        selections(in: lessons).randomElement()
+    }
+
+    static func selections(in lessons: [LessonContentModel]) -> [ShortRepeatPracticeSelection] {
+        var selections: [ShortRepeatPracticeSelection] = []
+
+        for lesson in lessons {
+            for task in lesson.practiceTasks {
+                let answerKey = lesson.answerKey.first { $0.taskId == task.id }
+
+                for item in task.items where PracticeAnswerEvaluator.isAutoGradable(item: item, answerKey: answerKey) {
+                    selections.append(
+                        ShortRepeatPracticeSelection(
+                            lessonID: lesson.id,
+                            taskID: task.id,
+                            itemID: item.id
+                        )
+                    )
+                }
+            }
+        }
+
+        return selections
+    }
+}
+
+struct PracticeSessionResult: Equatable {
+    let completedCount: Int
+    let gradableCount: Int
+    let correctCount: Int
+
+    var hasErrors: Bool {
+        gradableCount > correctCount
+    }
+}
+
+enum PracticeSessionMode: Hashable {
+    case standard
+    case shortRepeat(itemID: String)
+
+    var title: String {
+        switch self {
+        case .standard:
+            return "Practice"
+        case .shortRepeat:
+            return "Fast Repeat"
+        }
+    }
+
+    var updatesProgress: Bool {
+        switch self {
+        case .standard:
+            return true
+        case .shortRepeat:
+            return false
+        }
+    }
+}
+
 enum PracticeTaskResolver {
     static func selectedTask(
         in lesson: LessonContentModel,

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -13,8 +13,9 @@ struct PracticeView: View {
 
     private let requestedTaskID: String?
     private let providedLessonID: String?
+    private let mode: PracticeSessionMode
     var onBack: () -> Void
-    var onComplete: (LessonContentModel, LessonContentModel.PracticeTask) -> Void
+    var onComplete: (LessonContentModel, LessonContentModel.PracticeTask, PracticeSessionResult) -> Void
 
     @State private var activeTaskID: String?
     @State private var currentItemIndex = 0
@@ -25,12 +26,14 @@ struct PracticeView: View {
     init(
         lessonID: String? = nil,
         taskID: String? = nil,
+        mode: PracticeSessionMode = .standard,
         onBack: @escaping () -> Void,
-        onComplete: @escaping (LessonContentModel, LessonContentModel.PracticeTask) -> Void = { _, _ in }
+        onComplete: @escaping (LessonContentModel, LessonContentModel.PracticeTask, PracticeSessionResult) -> Void = { _, _, _ in }
     ) {
         _viewModel = StateObject(wrappedValue: LessonViewModel(lessonID: lessonID))
         self.providedLessonID = lessonID
         self.requestedTaskID = taskID
+        self.mode = mode
         self.onBack = onBack
         self.onComplete = onComplete
     }
@@ -50,7 +53,7 @@ struct PracticeView: View {
                         practiceContent(lesson: lesson, task: task)
                     }
                 } else {
-                    SLSTopBar(title: "Practice", backAction: onBack)
+                    SLSTopBar(title: mode.title, backAction: onBack)
                     errorContent
                 }
             }
@@ -71,7 +74,7 @@ struct PracticeView: View {
 
     private func practiceHeader(task: LessonContentModel.PracticeTask) -> some View {
         VStack(spacing: 0) {
-            SLSTopBar(title: "Practice", backAction: onBack, showsSeparator: false)
+            SLSTopBar(title: mode.title, backAction: onBack, showsSeparator: false)
 
             HStack(spacing: SLSSpacing.md) {
                 SLSProgressBar(value: progressValue(for: task))
@@ -460,8 +463,8 @@ struct PracticeView: View {
                         .lineSpacing(5)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    SLSPrimaryButton(title: "Continue") {
-                        onComplete(lesson, task)
+                    SLSPrimaryButton(title: completionActionTitle(for: task)) {
+                        onComplete(lesson, task, sessionResult(for: task))
                     }
                 }
             }
@@ -569,9 +572,13 @@ struct PracticeView: View {
             )
         case .advance:
             if isLastItem(in: task) {
-                isComplete = true
+                if case .shortRepeat = mode {
+                    onComplete(lesson, task, sessionResult(for: task))
+                } else {
+                    isComplete = true
+                }
             } else {
-                currentItemIndex = min(currentItemIndex + 1, task.items.count - 1)
+                currentItemIndex = min(currentItemIndex + 1, sessionItems(in: task).count - 1)
             }
         }
     }
@@ -595,12 +602,22 @@ struct PracticeView: View {
         lesson.answerKey.first { $0.taskId == task.id }
     }
 
+    private func sessionItems(in task: LessonContentModel.PracticeTask) -> [LessonContentModel.TaskItem] {
+        switch mode {
+        case .standard:
+            return task.items
+        case .shortRepeat(let itemID):
+            return task.items.filter { $0.id == itemID }
+        }
+    }
+
     private func currentItem(in task: LessonContentModel.PracticeTask) -> LessonContentModel.TaskItem? {
-        guard !task.items.isEmpty else {
+        let items = sessionItems(in: task)
+        guard !items.isEmpty else {
             return nil
         }
 
-        return task.items[min(currentItemIndex, task.items.count - 1)]
+        return items[min(currentItemIndex, items.count - 1)]
     }
 
     private func syncProgress() {
@@ -612,7 +629,9 @@ struct PracticeView: View {
             resetSession(for: task)
         }
 
-        progress.updatePracticeProgress(lessonID: providedLessonID ?? lesson.id, taskID: task.id)
+        if mode.updatesProgress {
+            progress.updatePracticeProgress(lessonID: providedLessonID ?? lesson.id, taskID: task.id)
+        }
     }
 
     private func resetSession(for task: LessonContentModel.PracticeTask) {
@@ -620,7 +639,7 @@ struct PracticeView: View {
         currentItemIndex = 0
         responses = [:]
         evaluations = [:]
-        isComplete = task.items.isEmpty
+        isComplete = sessionItems(in: task).isEmpty
     }
 
     private func responseBinding(for item: LessonContentModel.TaskItem) -> Binding<String> {
@@ -632,7 +651,8 @@ struct PracticeView: View {
     }
 
     private func progressValue(for task: LessonContentModel.PracticeTask) -> Double {
-        guard !task.items.isEmpty else {
+        let items = sessionItems(in: task)
+        guard !items.isEmpty else {
             return 1
         }
 
@@ -640,19 +660,20 @@ struct PracticeView: View {
             return 1
         }
 
-        return Double(currentItemIndex + 1) / Double(task.items.count)
+        return Double(currentItemIndex + 1) / Double(items.count)
     }
 
     private func progressText(for task: LessonContentModel.PracticeTask) -> String {
-        guard !task.items.isEmpty else {
+        let items = sessionItems(in: task)
+        guard !items.isEmpty else {
             return "0/0"
         }
 
         if isComplete {
-            return "\(task.items.count)/\(task.items.count)"
+            return "\(items.count)/\(items.count)"
         }
 
-        return "\(currentItemIndex + 1)/\(task.items.count)"
+        return "\(currentItemIndex + 1)/\(items.count)"
     }
 
     private func itemLabel(for item: LessonContentModel.TaskItem, index: Int) -> String {
@@ -678,7 +699,7 @@ struct PracticeView: View {
     }
 
     private func isLastItem(in task: LessonContentModel.PracticeTask) -> Bool {
-        currentItemIndex >= task.items.count - 1
+        currentItemIndex >= sessionItems(in: task).count - 1
     }
 
     private func openEndedActionTitle(for item: LessonContentModel.TaskItem) -> String {
@@ -726,15 +747,33 @@ struct PracticeView: View {
     }
 
     private func summaryText(for task: LessonContentModel.PracticeTask) -> String {
-        let completedCount = evaluations.count
-        let gradableEvaluations = evaluations.values.filter(\.isGradable)
-        let correctCount = gradableEvaluations.filter(\.isCorrect).count
+        let result = sessionResult(for: task)
 
-        if gradableEvaluations.isEmpty {
-            return "Completed \(completedCount) of \(task.items.count) items. This task is teacher-assessed, so it is not included in the score."
+        if result.gradableCount == 0 {
+            return "Completed \(result.completedCount) of \(sessionItems(in: task).count) items. This task is teacher-assessed, so it is not included in the score."
         }
 
-        return "Completed \(completedCount) of \(task.items.count) items.\nScore: \(correctCount) of \(gradableEvaluations.count) auto-graded items."
+        return "Completed \(result.completedCount) of \(sessionItems(in: task).count) items.\nScore: \(result.correctCount) of \(result.gradableCount) auto-graded items."
+    }
+
+    private func completionActionTitle(for task: LessonContentModel.PracticeTask) -> String {
+        guard case .shortRepeat = mode else {
+            return "Continue"
+        }
+
+        return sessionResult(for: task).hasErrors ? "Review Theory" : "Done"
+    }
+
+    private func sessionResult(for task: LessonContentModel.PracticeTask) -> PracticeSessionResult {
+        let itemIDs = Set(sessionItems(in: task).map(\.id))
+        let sessionEvaluations = evaluations.filter { itemIDs.contains($0.key) }.map(\.value)
+        let gradableEvaluations = sessionEvaluations.filter(\.isGradable)
+
+        return PracticeSessionResult(
+            completedCount: sessionEvaluations.count,
+            gradableCount: gradableEvaluations.count,
+            correctCount: gradableEvaluations.filter(\.isCorrect).count
+        )
     }
 }
 

--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -13,15 +13,18 @@ struct StartView: View {
     @StateObject private var viewModel: StartViewModel
 
     var onStartLearning: () -> Void
+    var onStartShortRepeat: () -> Void
     var onSelectLesson: (LessonContentModel) -> Void
 
     init(
         viewModel: @autoclosure @escaping () -> StartViewModel = StartViewModel(),
         onStartLearning: @escaping () -> Void,
+        onStartShortRepeat: @escaping () -> Void,
         onSelectLesson: @escaping (LessonContentModel) -> Void
     ) {
         _viewModel = StateObject(wrappedValue: viewModel())
         self.onStartLearning = onStartLearning
+        self.onStartShortRepeat = onStartShortRepeat
         self.onSelectLesson = onSelectLesson
     }
 
@@ -37,6 +40,7 @@ struct StartView: View {
                     if viewModel.lessons.isEmpty {
                         errorContent
                     } else {
+                        shortRepeatCard
                         lessonCatalog
                     }
                 }
@@ -101,6 +105,42 @@ struct StartView: View {
                 )
             }
         }
+    }
+
+    private var shortRepeatCard: some View {
+        Button(action: onStartShortRepeat) {
+            SLSCard {
+                HStack(alignment: .center, spacing: SLSSpacing.md) {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 46, height: 46)
+                        .background(SLSColors.brand)
+                        .clipShape(RoundedRectangle(cornerRadius: SLSRadius.md, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Fast / short repeat mode")
+                            .font(SLSTypography.cardTitle)
+                            .foregroundStyle(SLSColors.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text("One random practice. Mistakes open the related theory.")
+                            .font(SLSTypography.body)
+                            .foregroundStyle(SLSColors.textSecondary)
+                            .lineSpacing(3)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: SLSSpacing.sm)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(SLSColors.brand)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("fast-short-repeat-mode")
     }
 
     private var errorContent: some View {
@@ -228,6 +268,6 @@ private struct CatalogMetric: View {
 }
 
 #Preview {
-    StartView(onStartLearning: {}, onSelectLesson: { _ in })
+    StartView(onStartLearning: {}, onStartShortRepeat: {}, onSelectLesson: { _ in })
         .environmentObject(ProgressEnvironment())
 }

--- a/SamuiLanguageSchool/Models/LearningStepResolver.swift
+++ b/SamuiLanguageSchool/Models/LearningStepResolver.swift
@@ -66,4 +66,30 @@ enum LearningStepResolver {
 
         return allSteps[nextIndex]
     }
+
+    static func relevantTheorySection(
+        forPracticeTaskID taskID: String,
+        in lesson: LessonContentModel
+    ) -> LessonContentModel.TheorySection? {
+        if let linkedSection = lesson.orderedTheorySections.first(where: { $0.tryItTaskIds.contains(taskID) }) {
+            return linkedSection
+        }
+
+        var latestTheorySectionID: String?
+        for step in steps(for: lesson) {
+            switch step {
+            case .theory(_, let sectionID):
+                latestTheorySectionID = sectionID
+            case .practice(_, let practiceTaskID) where practiceTaskID == taskID:
+                if let latestTheorySectionID {
+                    return lesson.theorySections.first { $0.id == latestTheorySectionID }
+                }
+                return lesson.firstTheorySection
+            case .practice:
+                continue
+            }
+        }
+
+        return lesson.firstTheorySection
+    }
 }

--- a/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
+++ b/SamuiLanguageSchoolTests/SamuiLanguageSchoolTests.swift
@@ -74,6 +74,34 @@ struct SamuiLanguageSchoolTests {
         )
     }
 
+    @MainActor
+    @Test func learningStepResolverFindsRelevantTheoryForPracticeTask() async throws {
+        let lesson = Self.lesson(
+            tasks: [
+                Self.practiceTask(id: "try-it-task"),
+                Self.practiceTask(id: "activity-task")
+            ],
+            theorySections: [
+                Self.theorySection(id: "first-section", order: 1),
+                Self.theorySection(id: "linked-section", order: 2, tryItTaskIds: ["try-it-task"])
+            ]
+        )
+
+        #expect(
+            LearningStepResolver.relevantTheorySection(
+                forPracticeTaskID: "try-it-task",
+                in: lesson
+            )?.id == "linked-section"
+        )
+
+        #expect(
+            LearningStepResolver.relevantTheorySection(
+                forPracticeTaskID: "activity-task",
+                in: lesson
+            )?.id == "linked-section"
+        )
+    }
+
     @Test func difficultyGuideTitleListUsesActivityNumbers() async throws {
         let titles = [
             "Activity 2 - Articles across a paragraph",
@@ -315,6 +343,45 @@ struct SamuiLanguageSchoolTests {
     }
 
     @MainActor
+    @Test func shortRepeatPracticeSelectorUsesOnlyAutoGradableItems() async throws {
+        let lesson = Self.lesson(
+            tasks: [
+                Self.practiceTask(
+                    id: "gradable-task",
+                    items: [
+                        Self.taskItem(id: "item-1", type: .gapFill),
+                        Self.taskItem(id: "item-2", type: .freeResponse)
+                    ]
+                ),
+                Self.practiceTask(
+                    id: "unkeyed-task",
+                    items: [
+                        Self.taskItem(id: "item-3", type: .gapFill)
+                    ]
+                )
+            ],
+            answerKey: [
+                Self.answerKey(
+                    taskId: "gradable-task",
+                    entries: [
+                        Self.answerEntry(itemId: "item-1", answer: .string("the"))
+                    ]
+                )
+            ]
+        )
+
+        #expect(
+            ShortRepeatPracticeSelector.selections(in: [lesson]) == [
+                ShortRepeatPracticeSelection(
+                    lessonID: "lesson",
+                    taskID: "gradable-task",
+                    itemID: "item-1"
+                )
+            ]
+        )
+    }
+
+    @MainActor
     @Test func practiceTaskResolverUsesRequestedTaskWhenValid() async throws {
         let lesson = Self.lesson(tasks: [
             Self.practiceTask(id: "first-task"),
@@ -394,9 +461,14 @@ struct SamuiLanguageSchoolTests {
 
     private static func lesson(
         tasks: [LessonContentModel.PracticeTask],
-        answerKey: [LessonContentModel.AnswerKeyTask] = []
+        answerKey: [LessonContentModel.AnswerKeyTask] = [],
+        theorySections: [LessonContentModel.TheorySection]? = nil
     ) -> LessonContentModel {
-        LessonContentModel(
+        let theorySections = theorySections ?? [
+            Self.theorySection(id: "section", order: 1)
+        ]
+
+        return LessonContentModel(
             id: "lesson",
             title: "Lesson",
             level: LessonContentModel.Level(code: "A1", label: "A1", descriptor: nil),
@@ -417,18 +489,24 @@ struct SamuiLanguageSchoolTests {
             objectives: [],
             difficultyGuide: [],
             review: nil,
-            theorySections: [
-                LessonContentModel.TheorySection(
-                    id: "section",
-                    title: "Section",
-                    order: 1,
-                    contentBlocks: [],
-                    tryItTaskIds: []
-                )
-            ],
+            theorySections: theorySections,
             practiceTasks: tasks,
             answerKey: answerKey,
             selfAssessment: nil
+        )
+    }
+
+    private static func theorySection(
+        id: String,
+        order: Int,
+        tryItTaskIds: [String] = []
+    ) -> LessonContentModel.TheorySection {
+        LessonContentModel.TheorySection(
+            id: id,
+            title: "Section",
+            order: order,
+            contentBlocks: [],
+            tryItTaskIds: tryItTaskIds
         )
     }
 


### PR DESCRIPTION
## Summary
- Added a Home screen entry for `Fast / short repeat mode` that launches one random auto-gradable practice item.
- Added short-repeat session handling in practice so a single item is shown, then completion routes back to theory when mistakes are made.
- Added theory-section lookup logic and tests to cover short-repeat selection and fallback routing.

Resolves  #24

## Testing
- Ran the app build successfully.
- Ran the full test suite on the iPhone 17 simulator successfully, including the new unit tests for short-repeat selection and theory routing.