### PR TITLE
Remove lesson timing labels from lesson content and screens

### DIFF
--- a/SamuiLanguageSchool/Data/LessonContent.schema.json
+++ b/SamuiLanguageSchool/Data/LessonContent.schema.json
@@ -80,8 +80,7 @@
         "themeTitle",
         "levelLabel",
         "lessonBadge",
-        "shortDescription",
-        "estimatedReadTimeLabel"
+        "shortDescription"
       ],
       "properties": {
         "themeTitle": {
@@ -527,7 +526,6 @@
         "title",
         "level",
         "subtitle",
-        "estimatedMinutes",
         "tags",
         "source",
         "screenSummary",

--- a/SamuiLanguageSchool/Data/lessons.json
+++ b/SamuiLanguageSchool/Data/lessons.json
@@ -8,10 +8,6 @@
       "descriptor": "Intermediate to Upper-Intermediate"
     },
     "subtitle": "Use articles accurately across paragraphs, with abstract nouns, and in high-frequency fixed phrases.",
-    "estimatedMinutes": {
-      "min": 70,
-      "max": 85
-    },
     "tags": [
       "grammar",
       "articles",
@@ -30,7 +26,6 @@
       "levelLabel": "B1-B2",
       "lessonBadge": "Lesson: Articles Part 2",
       "shortDescription": "Track a/an and the across paragraphs, use articles with abstract nouns, and handle shared-reference nouns like the internet and the weather.",
-      "estimatedReadTimeLabel": "70-85 min",
       "primaryPracticeLabel": "Start Article Practice",
       "progressLabel": "3 theory sections, 7 activities"
     },
@@ -1299,10 +1294,6 @@
       "descriptor": "Intermediate"
     },
     "subtitle": "Use conditional linkers to talk about restrictions, requirements, and consequences in everyday adult life.",
-    "estimatedMinutes": {
-      "min": 75,
-      "max": 90
-    },
     "tags": [
       "grammar",
       "conditionals",
@@ -1322,7 +1313,6 @@
       "levelLabel": "B1 Intermediate",
       "lessonBadge": "Lesson: Conditional Linkers",
       "shortDescription": "Choose between unless and as long as, rewrite if-not conditions, and avoid common errors in condition clauses.",
-      "estimatedReadTimeLabel": "75-90 min",
       "primaryPracticeLabel": "Start Conditional Linker Practice",
       "progressLabel": "3 theory sections, 7 activities"
     },
@@ -2618,10 +2608,6 @@
       "descriptor": "Intermediate"
     },
     "subtitle": "Use reflexive pronouns accurately in conversation, writing, and your daily life.",
-    "estimatedMinutes": {
-      "min": 75,
-      "max": 90
-    },
     "tags": [
       "grammar",
       "pronouns",
@@ -2640,7 +2626,6 @@
       "levelLabel": "B1 Intermediate",
       "lessonBadge": "Lesson: Reflexive Pronouns",
       "shortDescription": "Use the eight reflexive pronoun forms, distinguish object and emphatic uses, and use by + reflexive for alone or without help.",
-      "estimatedReadTimeLabel": "75-90 min",
       "primaryPracticeLabel": "Start Pronoun Practice",
       "progressLabel": "3 grammar references, 9 activities"
     },

--- a/SamuiLanguageSchool/Features/Lesson/LessonView.swift
+++ b/SamuiLanguageSchool/Features/Lesson/LessonView.swift
@@ -156,7 +156,6 @@ private struct LessonSummaryHero: View {
             }
 
             HStack(spacing: SLSSpacing.md) {
-                SummaryMetric(iconName: "clock", label: summary.estimatedReadTimeLabel)
                 if let progressLabel = summary.progressLabel {
                     SummaryMetric(iconName: "checklist", label: progressLabel)
                 }

--- a/SamuiLanguageSchool/Features/Practice/PracticeView.swift
+++ b/SamuiLanguageSchool/Features/Practice/PracticeView.swift
@@ -691,10 +691,6 @@ struct PracticeView: View {
             parts.append(difficulty)
         }
 
-        if let estimatedMinutes = task.estimatedMinutes {
-            parts.append("\(estimatedMinutes.min)-\(estimatedMinutes.max) min")
-        }
-
         return parts.isEmpty ? nil : parts.joined(separator: " | ")
     }
 

--- a/SamuiLanguageSchool/Features/Start/StartView.swift
+++ b/SamuiLanguageSchool/Features/Start/StartView.swift
@@ -228,10 +228,8 @@ private struct LessonCatalogCard: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    HStack(spacing: SLSSpacing.sm) {
-                        CatalogMetric(iconName: "clock", text: lesson.screenSummary.estimatedReadTimeLabel)
-
-                        if let progressLabel = lesson.screenSummary.progressLabel {
+                    if let progressLabel = lesson.screenSummary.progressLabel {
+                        HStack(spacing: SLSSpacing.sm) {
                             CatalogMetric(iconName: "checklist", text: progressLabel)
                         }
                     }

--- a/SamuiLanguageSchool/Features/Theory/TheoryView.swift
+++ b/SamuiLanguageSchool/Features/Theory/TheoryView.swift
@@ -139,14 +139,6 @@ private struct TheoryHeroCard: View {
                 )
 
                 Spacer(minLength: SLSSpacing.sm)
-
-                Text(summary.estimatedReadTimeLabel)
-                    .font(SLSTypography.caption)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(.white.opacity(0.18))
-                    .clipShape(Capsule())
             }
 
             VStack(alignment: .leading, spacing: 10) {

--- a/SamuiLanguageSchool/Models/LessonContentModel.swift
+++ b/SamuiLanguageSchool/Models/LessonContentModel.swift
@@ -12,7 +12,7 @@ struct LessonContentModel: Decodable, Identifiable {
     let title: String
     let level: Level
     let subtitle: String
-    let estimatedMinutes: EstimatedMinutes
+    let estimatedMinutes: EstimatedMinutes?
     let tags: [String]
     let source: Source
     let screenSummary: ScreenSummary
@@ -49,7 +49,7 @@ extension LessonContentModel {
         let levelLabel: String
         let lessonBadge: String
         let shortDescription: String
-        let estimatedReadTimeLabel: String
+        let estimatedReadTimeLabel: String?
         let primaryPracticeLabel: String?
         let progressLabel: String?
     }


### PR DESCRIPTION
## Summary
- Removed lesson timing metadata from bundled lesson content and schema so lessons no longer advertise `70-85 min` style estimates.
- Dropped the visible clock/duration badges from the lesson catalog, lesson summary hero, and theory hero.
- Stopped practice task metadata from appending estimated minute ranges.
- Made lesson timing fields optional in the content model to match the updated data shape.

Resolves #15

## Testing
- Validated the updated JSON files.
- Ran the app test suite locally on the available iPhone 17 simulator; tests passed.